### PR TITLE
Add kustomize file generation

### DIFF
--- a/docs/data-sources/sync.md
+++ b/docs/data-sources/sync.md
@@ -43,6 +43,8 @@ data "flux_sync" "main" {
 ### Read-only
 
 - **content** (String, Read-only) Manifests in multi-doc yaml format.
+- **kustomize_content** (String, Read-only) Kustomize yaml document.
+- **kustomize_path** (String, Read-only) Expected path of kustomize content in git repository.
 - **path** (String, Read-only) Expected path of content in git repository.
 
 

--- a/docs/guides/github.md
+++ b/docs/guides/github.md
@@ -136,7 +136,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.install]
 
   metadata {
-    name      = data.flux_sync.main.name
+    name      = data.flux_sync.main.namespace
     namespace = data.flux_sync.main.namespace
   }
 
@@ -173,6 +173,13 @@ resource "github_repository_file" "sync" {
   repository = github_repository.main.name
   file       = data.flux_sync.main.path
   content    = data.flux_sync.main.content
+  branch     = var.branch
+}
+
+resource "github_repository_file" "kustomize" {
+  repository = github_repository.main.name
+  file       = data.flux_sync.main.kustomize_path
+  content    = data.flux_sync.main.kustomize_content
   branch     = var.branch
 }
 ```

--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -77,7 +77,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.install]
 
   metadata {
-    name      = data.flux_sync.main.name
+    name      = data.flux_sync.main.namespace
     namespace = data.flux_sync.main.namespace
   }
 

--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -116,3 +116,10 @@ resource "github_repository_file" "sync" {
   content    = data.flux_sync.main.content
   branch     = var.branch
 }
+
+resource "github_repository_file" "kustomize" {
+  repository = github_repository.main.name
+  file       = data.flux_sync.main.kustomize_path
+  content    = data.flux_sync.main.kustomize_content
+  branch     = var.branch
+}

--- a/pkg/provider/data_sync_test.go
+++ b/pkg/provider/data_sync_test.go
@@ -46,12 +46,14 @@ func TestAccDataSync_basic(t *testing.T) {
 				Config: testAccDataSyncBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "content"),
+					resource.TestCheckResourceAttrSet(resourceName, "kustomize_content"),
 					resource.TestCheckResourceAttr(resourceName, "namespace", "flux-system"),
 					resource.TestCheckResourceAttr(resourceName, "url", "ssh://git@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "branch", "main"),
 					resource.TestCheckResourceAttr(resourceName, "target_path", "staging-cluster"),
 					resource.TestCheckResourceAttr(resourceName, "interval", fmt.Sprintf("%d", time.Minute)),
 					resource.TestCheckResourceAttr(resourceName, "path", "staging-cluster/flux-system/gotk-sync.yaml"),
+					resource.TestCheckResourceAttr(resourceName, "kustomize_path", "staging-cluster/flux-system/kustomization.yaml"),
 				),
 			},
 			// Ensure attribute value changes are propagated correctly into the state

--- a/pkg/provider/util.go
+++ b/pkg/provider/util.go
@@ -17,6 +17,9 @@ limitations under the License.
 package provider
 
 import (
+	"bytes"
+	"text/template"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -33,3 +36,27 @@ func toStringList(ll interface{}) []string {
 
 	return result
 }
+
+func generateKustomizationYaml(paths []string) (string, error) {
+	t, err := template.New("kustomize").Parse(kustomizeTemplateString)
+	if err != nil {
+		return "", err
+	}
+
+	var kustomize bytes.Buffer
+	err = t.Execute(&kustomize, paths)
+	if err != nil {
+		return "", err
+	}
+
+	return kustomize.String(), nil
+}
+
+const kustomizeTemplateString = `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+{{- range . }}
+- {{.}}
+{{- end }}
+`

--- a/pkg/provider/util_test.go
+++ b/pkg/provider/util_test.go
@@ -36,3 +36,18 @@ func TestStringListNil(t *testing.T) {
 
 	assert.Equal(t, list, []string{})
 }
+
+func TestGenereateKustomizationYaml(t *testing.T) {
+	result, err := generateKustomizationYaml([]string{"foo", "bar"})
+
+	expected := `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- foo
+- bar
+`
+
+	assert.Nil(t, err)
+	assert.Equal(t, result, expected)
+}


### PR DESCRIPTION
The change adds extra computed fields to the sync data source for the kustomization file that is expected to be added to the git repository together with the other manifests.

Fixes #22 