### PR TITLE
Add e2e test with terraform apply to kind cluster

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,4 @@
-name: build
+name: e2e
 
 on:
   pull_request:
@@ -23,6 +23,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.15.x
+      - name: Setup Kubernetes
+        uses: engineerd/setup-kind@v0.4.0
+        with:
+          image: kindest/node:v1.16.9
       - name: Install tfplugindocs
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin
@@ -41,3 +45,11 @@ jobs:
             echo 'run make test and commit changes'
             exit 1
           fi
+      - name: Run install terraform
+        run: |
+          mkdir -p ./examples/install/.terraform/plugins/registry.terraform.io/fluxcd/flux/0.0.1/linux_amd64
+          cp ./bin/flux ./examples/install/.terraform/plugins/registry.terraform.io/fluxcd/flux/0.0.1/linux_amd64/terraform-provider-flux_v0.0.1
+          cd examples/install
+          terraform init
+          terraform apply -auto-approve
+

--- a/examples/install/main.tf
+++ b/examples/install/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 1.13.3"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.9.1"
+    }
+    flux = {
+      source  = "fluxcd/flux"
+      version = ">= 0.0.1"
+    }
+  }
+}
+
+provider "flux" {}
+
+provider "kubectl" {}
+
+# Flux
+data "flux_install" "main" {
+  target_path = var.target_path
+}
+
+# Kubernetes
+data "kubectl_file_documents" "install" {
+  content = data.flux_install.main.content
+}
+
+resource "kubectl_manifest" "install" {
+  for_each  = { for v in data.kubectl_file_documents.install.documents : sha1(v) => v }
+  yaml_body = each.value
+}

--- a/examples/install/variables.tf
+++ b/examples/install/variables.tf
@@ -1,0 +1,19 @@
+variable "repository_name" {
+  type    = string
+  default = "test-provider"
+}
+
+variable "repository_visibility" {
+  type    = string
+  default = "private"
+}
+
+variable "branch" {
+  type    = string
+  default = "main"
+}
+
+variable "target_path" {
+  type    = string
+  default = "staging-cluster"
+}


### PR DESCRIPTION
Change build GitHub action to include applying the install example to a kind cluster to verify the provider works in a simple use case.

Fixes #25 