### PR TITLE
Add apply retry count to examples

### DIFF
--- a/docs/guides/github.md
+++ b/docs/guides/github.md
@@ -82,7 +82,9 @@ terraform {
 
 provider "flux" {}
 
-provider "kubectl" {}
+provider "kubectl" {
+  apply_retry_count = 15
+}
 
 provider "kubernetes" {}
 

--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -23,7 +23,9 @@ terraform {
 
 provider "flux" {}
 
-provider "kubectl" {}
+provider "kubectl" {
+  apply_retry_count = 15
+}
 
 provider "kubernetes" {}
 

--- a/examples/install/main.tf
+++ b/examples/install/main.tf
@@ -19,7 +19,9 @@ terraform {
 
 provider "flux" {}
 
-provider "kubectl" {}
+provider "kubectl" {
+  apply_retry_count = 15
+}
 
 # Flux
 data "flux_install" "main" {


### PR DESCRIPTION
Adding a retry count to the kubectl provider helps dealing with if any of the ordering of the resources become wrong. Allowing resources to retry their apply will avoid failing if the only thing required is applying again.