### PR TITLE
Added name property in data_sync resource

### DIFF
--- a/docs/data-sources/sync.md
+++ b/docs/data-sources/sync.md
@@ -38,6 +38,7 @@ data "flux_sync" "main" {
 - **branch** (String, Optional) Default branch to sync from. Defaults to `main`.
 - **id** (String, Optional) The ID of this resource.
 - **interval** (Number, Optional) Sync interval. Defaults to `1m0s`.
+- **name** (String, Optional) The kubernetes resources name Defaults to `flux-system`.
 - **namespace** (String, Optional) The namespace scope for this operation. Defaults to `flux-system`.
 
 ### Read-only

--- a/docs/guides/github.md
+++ b/docs/guides/github.md
@@ -144,7 +144,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.install]
 
   metadata {
-    name      = data.flux_sync.main.namespace
+    name      = data.flux_sync.main.name
     namespace = data.flux_sync.main.namespace
   }
 

--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -85,7 +85,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.install]
 
   metadata {
-    name      = data.flux_sync.main.namespace
+    name      = data.flux_sync.main.name
     namespace = data.flux_sync.main.namespace
   }
 

--- a/pkg/provider/data_sync.go
+++ b/pkg/provider/data_sync.go
@@ -40,6 +40,12 @@ func DataSync() *schema.Resource {
 		Description: "`flux_sync` can be used to generate manifests for reconciling the specified repository path on the cluster.",
 		ReadContext: dataSyncRead,
 		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "The kubernetes resources name",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     syncDefaults.Namespace,
+			},
 			"namespace": {
 				Description: "The namespace scope for this operation.",
 				Type:        schema.TypeString,
@@ -98,7 +104,7 @@ func dataSyncRead(ctx context.Context, d *schema.ResourceData, m interface{}) di
 	interval := d.Get("interval").(int)
 	opt.Interval = time.Duration(interval)
 	opt.URL = d.Get("url").(string)
-	opt.Name = d.Get("namespace").(string)
+	opt.Name = d.Get("name").(string)
 	opt.Namespace = d.Get("namespace").(string)
 	opt.Branch = d.Get("branch").(string)
 	opt.TargetPath = d.Get("target_path").(string)

--- a/pkg/provider/data_sync_test.go
+++ b/pkg/provider/data_sync_test.go
@@ -67,6 +67,10 @@ func TestAccDataSync_basic(t *testing.T) {
 				Check:  resource.TestCheckResourceAttr(resourceName, "namespace", "test-system"),
 			},
 			{
+				Config: testAccDataSyncWithArg("name", "my-flux-install"),
+				Check:  resource.TestCheckResourceAttr(resourceName, "name", "my-flux-install"),
+			},
+			{
 				Config: testAccDataSyncWithArg("branch", "develop"),
 				Check:  resource.TestCheckResourceAttr(resourceName, "branch", "develop"),
 			},


### PR DESCRIPTION
Fix issue #40 

Use the `syncDefaults.Namespace` as default value to keep current behavior

Signed-off-by: Vincent Lainé <2082554+phenixdotnet@users.noreply.github.com>