### PR TITLE
Ignore label changes to flux-system namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ resource "kubernetes_namespace" "flux_system" {
   metadata {
     name = "flux-system"
   }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].labels,
+    ]
+  }
 }
 
 # Split multi-doc YAML with

--- a/docs/guides/github.md
+++ b/docs/guides/github.md
@@ -112,6 +112,12 @@ resource "kubernetes_namespace" "flux_system" {
   metadata {
     name = "flux-system"
   }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].labels,
+    ]
+  }
 }
 
 data "kubectl_file_documents" "install" {

--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -53,6 +53,12 @@ resource "kubernetes_namespace" "flux_system" {
   metadata {
     name = "flux-system"
   }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].labels,
+    ]
+  }
 }
 
 data "kubectl_file_documents" "install" {


### PR DESCRIPTION
This is required as the namespace that is created before installing flux does not contain labels later set. If we do not ignore the changes it will bounce back between adding and removing the labels.