### PR TITLE
fix: make secretRef configurable and backwards-compatible

### DIFF
--- a/docs/data-sources/sync.md
+++ b/docs/data-sources/sync.md
@@ -43,6 +43,7 @@ data "flux_sync" "main" {
 - **interval** (Number) Sync interval in minutes. Defaults to `1`.
 - **name** (String) The kubernetes resources name Defaults to `flux-system`.
 - **namespace** (String) The namespace scope for this operation. Defaults to `flux-system`.
+- **secret** (String) The name of the secret that is referenced by GitRepository as SecretRef. Defaults to `flux-system`.
 
 ### Read-Only
 

--- a/pkg/provider/data_sync.go
+++ b/pkg/provider/data_sync.go
@@ -64,6 +64,12 @@ func DataSync() *schema.Resource {
 				Optional:    true,
 				Default:     syncDefaults.Branch,
 			},
+			"secret": {
+				Description: "The name of the secret that is referenced by GitRepository as SecretRef.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     syncDefaults.Secret,
+			},
 			"target_path": {
 				Description: "Relative path to the Git repository root where the sync manifests are committed.",
 				Type:        schema.TypeString,
@@ -115,6 +121,7 @@ func dataSyncRead(ctx context.Context, d *schema.ResourceData, m interface{}) di
 	opt.Branch = d.Get("branch").(string)
 	opt.TargetPath = d.Get("target_path").(string)
 	opt.GitImplementation = d.Get("git_implementation").(string)
+	opt.Secret = d.Get("secret").(string)
 	manifest, err := sync.Generate(opt)
 	if err != nil {
 		return diag.FromErr(err)

--- a/pkg/provider/data_sync_test.go
+++ b/pkg/provider/data_sync_test.go
@@ -67,6 +67,10 @@ func TestAccDataSync_basic(t *testing.T) {
 				Check:  resource.TestCheckResourceAttr(resourceName, "namespace", "test-system"),
 			},
 			{
+				Config: testAccDataSyncWithArg("secret", "my-secret"),
+				Check:  resource.TestCheckResourceAttr(resourceName, "secret", "my-secret"),
+			},
+			{
 				Config: testAccDataSyncWithArg("name", "my-flux-install"),
 				Check:  resource.TestCheckResourceAttr(resourceName, "name", "my-flux-install"),
 			},


### PR DESCRIPTION
This PR makes the `GitRepsository.spec.secretRef` configurable and ensures that the provider stays backwards compatible with the versions pre v0.0.13. 
In 0.0.13 the default secret-name is `flux-system`, before that it was the flux_sync resource name. Details in #104.



Closes #104