### PR TITLE
Fix examples to align with new secret property

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.apply]
 
   metadata {
-    name      = data.flux_sync.main.name
+    name      = data.flux_sync.main.secret
     namespace = data.flux_sync.main.namespace
   }
 

--- a/docs/guides/github.md
+++ b/docs/guides/github.md
@@ -69,20 +69,19 @@ terraform {
   required_providers {
     github = {
       source = "integrations/github"
-      # 4.3.1 is broken for personal account users
-      version = "4.3.0"
+      version = ">= 4.5.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0.1"
+      version = ">= 2.0.2"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = ">= 1.9.1"
+      version = ">= 1.10.0"
     }
     flux = {
       source  = "fluxcd/flux"
-      version = ">= 0.0.10"
+      version = ">= 0.0.13"
     }
     tls = {
       source  = "hashicorp/tls"
@@ -176,7 +175,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.install]
 
   metadata {
-    name      = data.flux_sync.main.name
+    name      = data.flux_sync.main.secret
     namespace = data.flux_sync.main.namespace
   }
 

--- a/docs/guides/gke_github.md
+++ b/docs/guides/gke_github.md
@@ -84,12 +84,12 @@ data sources `flux_install` and `flux_sync`. The cluster has been successfully a
 manifests are applied to it.
 ```terraform
 terraform {
-  required_version = ">= 0.12.10"
+  required_version = ">= 0.13"
 
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.5.1"
+      version = ">= 4.5.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -195,7 +195,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.install]
 
   metadata {
-    name      = data.flux_sync.main.name
+    name      = data.flux_sync.main.secret
     namespace = data.flux_sync.main.namespace
   }
 

--- a/docs/guides/multi-env.md
+++ b/docs/guides/multi-env.md
@@ -20,8 +20,7 @@ terraform {
   required_providers {
     github = {
       source = "integrations/github"
-      # 4.3.1 is broken for personal account users
-      version = "4.3.0"
+      version = "4.5.2"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/examples/github/main.tf
+++ b/examples/github/main.tf
@@ -4,20 +4,19 @@ terraform {
   required_providers {
     github = {
       source = "integrations/github"
-      # 4.3.1 is broken for personal account users
-      version = "4.3.0"
+      version = ">= 4.5.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0.1"
+      version = ">= 2.0.2"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = ">= 1.9.1"
+      version = ">= 1.10.0"
     }
     flux = {
       source  = "fluxcd/flux"
-      version = ">= 0.0.10"
+      version = ">= 0.0.13"
     }
     tls = {
       source  = "hashicorp/tls"
@@ -111,7 +110,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.install]
 
   metadata {
-    name      = data.flux_sync.main.name
+    name      = data.flux_sync.main.secret
     namespace = data.flux_sync.main.namespace
   }
 

--- a/examples/gke_github/main.tf
+++ b/examples/gke_github/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.10"
+  required_version = ">= 0.13"
 
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.5.1"
+      version = ">= 4.5.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -110,7 +110,7 @@ resource "kubernetes_secret" "main" {
   depends_on = [kubectl_manifest.install]
 
   metadata {
-    name      = data.flux_sync.main.name
+    name      = data.flux_sync.main.secret
     namespace = data.flux_sync.main.namespace
   }
 

--- a/examples/install/main.tf
+++ b/examples/install/main.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0.1"
+      version = ">= 2.0.2"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = ">= 1.9.1"
+      version = ">= 1.10.0"
     }
     flux = {
       source  = "fluxcd/flux"
-      version = ">= 0.0.10"
+      version = ">= 0.0.13"
     }
   }
 }

--- a/examples/multi-env/main.tf
+++ b/examples/multi-env/main.tf
@@ -4,8 +4,7 @@ terraform {
   required_providers {
     github = {
       source = "integrations/github"
-      # 4.3.1 is broken for personal account users
-      version = "4.3.0"
+      version = "4.5.2"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
Fixes the examples so the secrets created in the examples uses the secret and not the name. This aligns the examples with the latest changes in the provider. I also updated the provider versions to the latest, to remove any ambiguity between the different examples.