### PR TITLE
Fix invalid reference in gke_github

### DIFF
--- a/docs/guides/gke_github.md
+++ b/docs/guides/gke_github.md
@@ -214,7 +214,7 @@ provider "github" {
 
 # To make sure the repository exists and the correct permissions are set.
 data "github_repository" "main" {
-  full_name = "${var.organization}/${repository_name}"
+  full_name = "${var.organization}/${var.repository_name}"
 }
 
 resource "github_repository_file" "install" {

--- a/examples/gke_github/main.tf
+++ b/examples/gke_github/main.tf
@@ -129,7 +129,7 @@ provider "github" {
 
 # To make sure the repository exists and the correct permissions are set.
 data "github_repository" "main" {
-  full_name = "${var.organization}/${repository_name}"
+  full_name = "${var.organization}/${var.repository_name}"
 }
 
 resource "github_repository_file" "install" {


### PR DESCRIPTION
This example does not work, so fixed invalid reference.

```
Error: Invalid reference

  on .terraform/modules/flux/examples/gke_github/main.tf line 132, in data "github_repository" "main":
 132:   full_name = "${var.organization}/${repository_name}"

A reference to a resource type must be followed by at least one attribute
access, specifying the resource name.
```