### PR TITLE
concat components and componentsExtra

### DIFF
--- a/pkg/provider/data_install.go
+++ b/pkg/provider/data_install.go
@@ -147,6 +147,7 @@ func dataInstallRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	if len(componentsExtra) == 0 {
 		componentsExtra = installDefaults.ComponentsExtra
 	}
+	components = append(components, componentsExtra...)
 
 	tolerationKeys := toStringList(d.Get("toleration_keys"))
 	if len(tolerationKeys) == 0 {

--- a/pkg/provider/data_install_test.go
+++ b/pkg/provider/data_install_test.go
@@ -108,7 +108,10 @@ func TestAccDataInstall_basic(t *testing.T) {
 						}
 
 						content := install.Primary.Attributes["content"]
-						images := []string{"source-controller:v0.5.4", "kustomize-controller:v0.5.0", "notification-controller:v0.5.0", "helm-controller:v0.4.3"}
+						images := []string{
+							"source-controller:v0.5.4", "kustomize-controller:v0.5.0", "notification-controller:v0.5.0", "helm-controller:v0.4.3",
+							"image-automation-controller:v0.1.0", "image-reflector-controller:v0.1.0",
+						}
 						for _, image := range images {
 							imageKey := fmt.Sprintf("ghcr.io/fluxcd/%s", image)
 							if !strings.Contains(content, imageKey) {


### PR DESCRIPTION
Signed-off-by: Daniel Dabrowski <daniel.dabrowski@procure.ai>

This resolves issue #126 

Unfortunately the `utils.ValidateComponents` function is part of the internal flux2 package and not usable within this provider. Maybe it would make sense to Validate the opts within manifestgen package when calling `install.Generate`, but I do not think it should be duplicated in this repository.