### PR TITLE
Corrects 'invisible' typo

### DIFF
--- a/docs/guides/github.md
+++ b/docs/guides/github.md
@@ -37,7 +37,7 @@ variable "repository_name" {
 variable "repository_visibility" {
   type        = string
   default     = "private"
-  description = "How visiable is the github repo"
+  description = "How visible is the github repo"
 }
 
 variable "branch" {

--- a/examples/github/variables.tf
+++ b/examples/github/variables.tf
@@ -17,7 +17,7 @@ variable "repository_name" {
 variable "repository_visibility" {
   type        = string
   default     = "private"
-  description = "How visiable is the github repo"
+  description = "How visible is the github repo"
 }
 
 variable "branch" {


### PR DESCRIPTION
Noticed when reading the docs for use that there was a typo with `visible`.