### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.9.0
+
+**Release date:** 2022-01-19
+
+This prerelease includes flux2 [v0.25.3](https://github.com/fluxcd/flux2/releases/tag/v0.25.3).
+
+In addition, the provider is now built with Go 1.17.
+
 ## 0.8.1
 
 **Release date:** 2021-12-10

--- a/docs/data-sources/install.md
+++ b/docs/data-sources/install.md
@@ -41,7 +41,7 @@ data "flux_install" "main" {
 - **network_policy** (Boolean) Deny ingress access to the toolkit controllers from other namespaces using network policies. Defaults to `true`.
 - **registry** (String) Container registry where the toolkit images are published. Defaults to `ghcr.io/fluxcd`.
 - **toleration_keys** (Set of String) List of toleration keys used to schedule the components pods onto nodes with matching taints.
-- **version** (String) Flux version. Defaults to `v0.24.1`.
+- **version** (String) Flux version. Defaults to `v0.25.3`.
 - **watch_all_namespaces** (Boolean) If true watch for custom resources in all namespaces. Defaults to `true`.
 
 ### Read-Only

--- a/pkg/provider/data_install.go
+++ b/pkg/provider/data_install.go
@@ -47,7 +47,7 @@ func DataInstall() *schema.Resource {
 				Description: "Flux version.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "v0.24.1",
+				Default:     "v0.25.3",
 				ValidateFunc: func(val interface{}, key string) ([]string, []error) {
 					errs := []error{}
 					v := val.(string)


### PR DESCRIPTION
This version includes flux2 [v0.25.3](https://github.com/fluxcd/flux2/releases/tag/v0.25.3).

In addition, the provider is now built with Go 1.17.