### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.10.0
+
+**Release date:** 2022-02-01
+
+This prerelease includes flux2 [v0.26.0](https://github.com/fluxcd/flux2/releases/tag/v0.26.0).
+
+Note that Flux v0.26 comes with breaking changes, most notable,
+the minimum supported version of Kubernetes is now **v1.20.6**.
+While Flux may still work on Kubernetes 1.19, we don’t recommend running EOL versions in production
+as we don't run any conformance tests on Kubernetes versions that have reached end-of-life.
+
 ## 0.9.0
 
 **Release date:** 2022-01-19

--- a/docs/data-sources/install.md
+++ b/docs/data-sources/install.md
@@ -41,7 +41,7 @@ data "flux_install" "main" {
 - **network_policy** (Boolean) Deny ingress access to the toolkit controllers from other namespaces using network policies. Defaults to `true`.
 - **registry** (String) Container registry where the toolkit images are published. Defaults to `ghcr.io/fluxcd`.
 - **toleration_keys** (Set of String) List of toleration keys used to schedule the components pods onto nodes with matching taints.
-- **version** (String) Flux version. Defaults to `v0.25.3`.
+- **version** (String) Flux version. Defaults to `v0.26.0`.
 - **watch_all_namespaces** (Boolean) If true watch for custom resources in all namespaces. Defaults to `true`.
 
 ### Read-Only

--- a/pkg/provider/data_install.go
+++ b/pkg/provider/data_install.go
@@ -47,7 +47,7 @@ func DataInstall() *schema.Resource {
 				Description: "Flux version.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "v0.25.3",
+				Default:     "v0.26.0",
 				ValidateFunc: func(val interface{}, key string) ([]string, []error) {
 					errs := []error{}
 					v := val.(string)


### PR DESCRIPTION
This prerelease includes flux2 [v0.26.0](https://github.com/fluxcd/flux2/releases/tag/v0.26.0).

Note that Flux v0.26 comes with breaking changes, most notable,
the minimum supported version of Kubernetes is now **v1.20.6**.
While Flux may still work on Kubernetes 1.19, we don’t recommend running EOL versions in production
as we don't run any conformance tests on Kubernetes versions that have reached end-of-life.