### PR TITLE
Allow specifying the baseurl for flux_install data sources.

### DIFF
--- a/docs/data-sources/install.md
+++ b/docs/data-sources/install.md
@@ -31,6 +31,7 @@ data "flux_install" "main" {
 
 ### Optional
 
+- `baseurl` (String) Base URL to get the install manifests from. When specifying this, `version` should also be set to the corresponding version to download from that URL, or the latest version associated with upstream flux will be requested. Defaults to `https://github.com/fluxcd/flux2/releases`.
 - `cluster_domain` (String) The internal cluster domain. Defaults to `cluster.local`.
 - `components` (Set of String) Toolkit components to include in the install manifests.
 - `components_extra` (Set of String) List of extra components to include in the install manifests.

--- a/pkg/provider/data_install.go
+++ b/pkg/provider/data_install.go
@@ -134,6 +134,12 @@ func DataInstall() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"baseurl": {
+				Description: "Base URL to get the install manifests from. When specifying this, `version` should also be set to the corresponding version to download from that URL, or the latest version associated with upstream flux will be requested.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     installDefaults.BaseURL,
+			},
 		},
 	}
 }
@@ -166,6 +172,7 @@ func dataInstallRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	opt.NetworkPolicy = d.Get("network_policy").(bool)
 	opt.LogLevel = d.Get("log_level").(string)
 	opt.TargetPath = d.Get("target_path").(string)
+	opt.BaseURL = d.Get("baseurl").(string)
 	opt.TolerationKeys = tolerationKeys
 	manifest, err := install.Generate(opt, "")
 	if err != nil {

--- a/pkg/provider/data_install_test.go
+++ b/pkg/provider/data_install_test.go
@@ -55,6 +55,7 @@ func TestAccDataInstall_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "registry", "ghcr.io/fluxcd"),
 					resource.TestCheckResourceAttr(resourceName, "target_path", "staging-cluster"),
 					resource.TestCheckResourceAttr(resourceName, "watch_all_namespaces", "true"),
+					resource.TestCheckResourceAttr(resourceName, "baseurl", "https://github.com/fluxcd/flux2/releases"),
 				),
 			},
 			// Ensure attribute value changes are propagated correctly into the state
@@ -96,6 +97,10 @@ func TestAccDataInstall_basic(t *testing.T) {
 			{
 				Config:      testAccDataInstallWithArg("version", "foo"),
 				ExpectError: regexp.MustCompile("\"version\" must either be latest or have the prefix 'v', got: foo"),
+			},
+			{
+				Config:      testAccDataInstallWithArg("baseurl", "http://www.example.org"),
+				ExpectError: regexp.MustCompile("Error: failed to download manifests.tar.gz"),
 			},
 			{
 				Config: testAccDataInstallWithArg("version", "v0.5.3"),


### PR DESCRIPTION
This adds `baseurl` to the schema for `flux_install` data sources to allow fetching the flux manifests from an alternate GitHub or other HTTP location, such as an internal mirror. This was inspired by the existing issue https://github.com/fluxcd/terraform-provider-flux/issues/235.

This includes a test to ensure the default is set appropriately, and a test to ensure that with a nonstandard URL which is guaranteed to 404 (as much as [RFC 2606](https://www.iana.org/go/rfc2606) can be expected to be implemented), it fails as expected.