### PR TITLE
workflows/update: Use -compat=1.17 with tidy

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,7 +22,7 @@ jobs:
           CURRENT_VERSION=$(go list -m all | grep github.com/fluxcd/flux2 | awk '{print $2}')
           if [[ "${RELEASE_VERSION}" != "${CURRENT_VERSION}" ]]; then
             go mod edit -require github.com/fluxcd/flux2@${RELEASE_VERSION}
-            go mod tidy
+            go mod tidy -compat=1.17
           fi
           git diff
 


### PR DESCRIPTION
Fix the update workflow failure due to go mod tidy failure.

