### PR TITLE
make generated kustomize.yaml valid yaml

### DIFF
--- a/internal/utils/datasource.go
+++ b/internal/utils/datasource.go
@@ -52,7 +52,7 @@ func GenerateKustomizationYaml(paths []string, patches []string) (string, error)
 	return kustomize.String(), nil
 }
 
-const kustomizeTemplateString = `
+const kustomizeTemplateString = `---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -61,7 +61,7 @@ resources:
 {{- end }}
 `
 
-const kustomizeWithPatchesTemplateString = `
+const kustomizeWithPatchesTemplateString = `---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/internal/utils/datasource_test.go
+++ b/internal/utils/datasource_test.go
@@ -26,7 +26,7 @@ import (
 func TestGenereateKustomizationYamlWithNoPatches(t *testing.T) {
 	result, err := GenerateKustomizationYaml([]string{"foo", "bar"}, []string{})
 
-	expected := `
+	expected := `---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -41,7 +41,7 @@ resources:
 func TestGenereateKustomizationYamlWithPatches(t *testing.T) {
 	result, err := GenerateKustomizationYaml([]string{"foo", "bar"}, []string{"baz", "buzz"})
 
-	expected := `
+	expected := `---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
yamllint fails on the generated yaml as it starts with an empty line and not with `---`

Fixes https://github.com/fluxcd/terraform-provider-flux/issues/352