### PR TITLE
Update readme with example for bootstrapping Flux with resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,24 @@
 # Terraform provider flux
 
-This is the Terraform provider for Flux v2. The provider allows you to install Flux on Kubernetes
-and configure it to reconcile the cluster state from a Git repository.
+This is the Terraform provider for Flux v2. The provider allows you to install Flux on Kubernetes and configure it to reconcile the cluster state from a Git repository.
 
 ## Get started
 
-The provider consists of two data sources `flux_install` and `flux_sync`, which output the manifests
-required to install Flux.
-
-The `flux_install` data source generates a multi-doc YAML with Kubernetes manifests that can be used to install or upgrade Flux.
-
-```hcl
-# Generate manifests
-data "flux_install" "main" {
-  target_path    = "clusters/my-cluster"
-  network_policy = false
-}
-
-resource "kubernetes_namespace" "flux_system" {
-  metadata {
-    name = "flux-system"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      metadata[0].labels,
-    ]
-  }
-}
-
-# Split multi-doc YAML with
-# https://registry.terraform.io/providers/gavinbunney/kubectl/latest
-data "kubectl_file_documents" "apply" {
-  content = data.flux_install.main.content
-}
-
-# Convert documents list to include parsed yaml data
-locals {
-  apply = [ for v in data.kubectl_file_documents.apply.documents : {
-      data: yamldecode(v)
-      content: v
-    }
-  ]
-}
-
-# Apply manifests on the cluster
-resource "kubectl_manifest" "apply" {
-  for_each   = { for v in local.apply : lower(join("/", compact([v.data.apiVersion, v.data.kind, lookup(v.data.metadata, "namespace", ""), v.data.metadata.name]))) => v.content }
-  depends_on = [kubernetes_namespace.flux_system]
-  yaml_body = each.value
-}
-```
-
-The `flux_sync` data source generates a multi-doc YAML containing the `GitRepository` and `Kustomization`
-manifests that configures Flux to sync the cluster with the specified repository.
+Flux can be bootstrapped using Terraform with a single Terraform resource. The provider needs to be configured with Kubernetes credentials in the same way that the Kubernetes and Helm Terraform providers are configured.
+The resource is configured with the repository URL and git credentials. When applied the necessary Kubernetes manifests will be committed to the Git repository and applied to the Kubernetes cluster. Flux will then be 
+verified that it can synchronize from the configured Git repository.
 
 ```hcl
-# Generate manifests
-data "flux_sync" "main" {
-  target_path = "clusters/my-cluster"
-  url         = "https://github.com/${var.github_owner}/${var.repository_name}"
+provider "flux" {
+  config_path = "~/.kube/config"
 }
 
-# Split multi-doc YAML with
-# https://registry.terraform.io/providers/gavinbunney/kubectl/latest
-data "kubectl_file_documents" "sync" {
-  content = data.flux_sync.main.content
-}
-
-# Convert documents list to include parsed yaml data
-locals {
-  sync = [ for v in data.kubectl_file_documents.sync.documents : {
-      data: yamldecode(v)
-      content: v
-    }
-  ]
-}
-
-# Apply manifests on the cluster
-resource "kubectl_manifest" "sync" {
-  for_each   = { for v in local.sync : lower(join("/", compact([v.data.apiVersion, v.data.kind, lookup(v.data.metadata, "namespace", ""), v.data.metadata.name]))) => v.content }
-  depends_on = [kubernetes_namespace.flux_system]
-  yaml_body = each.value
-}
-
-# Generate a Kubernetes secret with the Git credentials
-resource "kubernetes_secret" "main" {
-  depends_on = [kubectl_manifest.apply]
-
-  metadata {
-    name      = data.flux_sync.main.secret
-    namespace = data.flux_sync.main.namespace
-  }
-
-  data = {
-    username = "git"
-    password = var.flux_token
+resource "flux_bootstrap_git" "this" {
+  url  = var.repository_ssh_url
+  path = "clusters/my-cluster"
+  ssh = {
+    username    = "git"
+    private_key = var.private_key_pem
   }
 }
 ```


### PR DESCRIPTION
The change removes the docs for the old bootstrap method and replaces them with docs for the new.