### PR TITLE
Fix bootstrap running when git history is empty

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -63,7 +63,7 @@ func (prd *providerResourceData) HasClients() bool {
 	return prd.rcg != nil && prd.manager != nil && prd.kubeClient != nil
 }
 
-func (prd *providerResourceData) GetGitClient(ctx context.Context, branch string) (*gogit.Client, error) {
+func (prd *providerResourceData) GetGitClient(ctx context.Context, branch string, clone bool) (*gogit.Client, error) {
 	tmpDir, err := manifestgen.MkdirTempAbs("", "flux-bootstrap-")
 	if err != nil {
 		return nil, fmt.Errorf("could not create temporary working directory for git repository: %w", err)
@@ -76,10 +76,11 @@ func (prd *providerResourceData) GetGitClient(ctx context.Context, branch string
 	if err != nil {
 		return nil, fmt.Errorf("could not create git client: %w", err)
 	}
-	// TODO: Need to conditionally clone here. If repository is empty this will fail.
-	_, err = client.Clone(ctx, prd.repositoryUrl.String(), repository.CloneOptions{CheckoutStrategy: repository.CheckoutStrategy{Branch: branch}})
-	if err != nil {
-		return nil, fmt.Errorf("could not clone git repository: %w", err)
+	if clone {
+		_, err = client.Clone(ctx, prd.repositoryUrl.String(), repository.CloneOptions{CheckoutStrategy: repository.CheckoutStrategy{Branch: branch}})
+		if err != nil {
+			return nil, fmt.Errorf("could not clone git repository: %w", err)
+		}
 	}
 	return client, nil
 }

--- a/internal/provider/resource_bootstrap_git.go
+++ b/internal/provider/resource_bootstrap_git.go
@@ -394,7 +394,8 @@ func (r *bootstrapGitResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	gitClient, err := r.prd.GetGitClient(ctx, data.Branch.ValueString())
+	hasKustomizationOverride := data.KustomizationOverride.ValueString() != ""
+	gitClient, err := r.prd.GetGitClient(ctx, data.Branch.ValueString(), hasKustomizationOverride)
 	if err != nil {
 		resp.Diagnostics.AddError("Git Client", err.Error())
 		return
@@ -451,7 +452,7 @@ func (r *bootstrapGitResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Write own kustomization file
-	if data.KustomizationOverride.ValueString() != "" {
+	if hasKustomizationOverride {
 		// Need to write empty gotk-components and gotk-sync because other wise Kustomize will not work.
 		basePath := filepath.Join(gitClient.Path(), data.Path.ValueString(), data.Namespace.ValueString())
 		files := map[string]io.Reader{
@@ -512,7 +513,7 @@ func (r *bootstrapGitResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	gitClient, err := r.prd.GetGitClient(ctx, data.Branch.ValueString())
+	gitClient, err := r.prd.GetGitClient(ctx, data.Branch.ValueString(), true)
 	if err != nil {
 		resp.Diagnostics.AddError("Git Client", err.Error())
 		return
@@ -554,7 +555,7 @@ func (r bootstrapGitResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	gitClient, err := r.prd.GetGitClient(ctx, data.Branch.ValueString())
+	gitClient, err := r.prd.GetGitClient(ctx, data.Branch.ValueString(), true)
 	if err != nil {
 		resp.Diagnostics.AddError("Git Client", err.Error())
 		return
@@ -640,7 +641,7 @@ func (r bootstrapGitResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	gitClient, err := r.prd.GetGitClient(ctx, data.Branch.ValueString())
+	gitClient, err := r.prd.GetGitClient(ctx, data.Branch.ValueString(), true)
 	if err != nil {
 		resp.Diagnostics.AddError("Git Client", err.Error())
 		return

--- a/internal/provider/resource_bootstrap_git_test.go
+++ b/internal/provider/resource_bootstrap_git_test.go
@@ -585,10 +585,9 @@ func setupEnvironment(t *testing.T) environment {
 	_, _, err = giteaClient.AdminCreateUser(createUserOpt)
 	require.NoError(t, err)
 	createRepoOpt := gitea.CreateRepoOption{
-		Name:          randSuffix,
-		AutoInit:      true,
-		DefaultBranch: defaultBranch,
-		Private:       true,
+		Name:     randSuffix,
+		AutoInit: false,
+		Private:  true,
 	}
 	repo, _, err := giteaClient.AdminCreateRepo(username, createRepoOpt)
 	require.NoError(t, err)


### PR DESCRIPTION
The issue does not come from any code in the provider, but from an incompatibility with the current bootstrap code. It does not expect an empty cloned repository when running and will fail. This is not an issue in the CLI bootstrap command because it does not clone the repository before the bootstrap function is run.

https://github.com/fluxcd/flux2/blob/2e4de673b229b3da1ef4aa613080bd05668d9f6e/pkg/bootstrap/bootstrap_plain_git.go#L112-L116

Fixes #365 
 