### PR TITLE
Fix import when extra components are configured

### DIFF
--- a/internal/provider/resource_bootstrap_git.go
+++ b/internal/provider/resource_bootstrap_git.go
@@ -908,7 +908,7 @@ func (r *bootstrapGitResource) ImportState(ctx context.Context, req resource.Imp
 			resp.Diagnostics.AddError(fmt.Sprintf("Could not get Deployment %s/%s", dep.Namespace, dep.Name), err.Error())
 			return
 		}
-		componentsExtra = append(components, types.StringValue(c))
+		componentsExtra = append(componentsExtra, types.StringValue(c))
 	}
 	componentsExtraSet, diags := types.SetValue(types.StringType, componentsExtra)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_bootstrap_git_test.go
+++ b/internal/provider/resource_bootstrap_git_test.go
@@ -251,6 +251,13 @@ func TestAccBootstrapGit_Components(t *testing.T) {
 					resource.TestCheckResourceAttrSet("flux_bootstrap_git.this", "repository_files.flux-system/gotk-sync.yaml"),
 				),
 			},
+			{
+				Config:            bootstrapGitComponents(env),
+				ResourceName:      "flux_bootstrap_git.this",
+				ImportState:       true,
+				ImportStateId:     "flux-system",
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
The import code contained an error when building the components and components extra slices. This caused the same component to be in the slice twice. This change fixes that issue and adds an import test step when configuring extra components.

Fixes #384
Fixes #392 