### PR TITLE
Fix client config init

### DIFF
--- a/internal/provider/provider_resource_data.go
+++ b/internal/provider/provider_resource_data.go
@@ -341,11 +341,5 @@ func getClientConfiguration(ctx context.Context, kubernetes *Kubernetes) (client
 	overrides.ClusterDefaults.ProxyURL = kubernetes.ProxyURL.ValueString()
 
 	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides)
-
-	// Validate that the Kubernetes configuration is correct.
-	if _, err := cc.ClientConfig(); err != nil {
-		return nil, err
-	}
-
 	return cc, nil
 }


### PR DESCRIPTION
Regression was introduced in the form of validating the Kubernetes config early. This can't be done if the Kubernetes cluster is created in the same Terraform state. I need to create a test in the future which covers this use case.