### PR TITLE
Change method to use locally built provider and add developer guide

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,7 +66,9 @@ jobs:
           GOOS: linux
           GOARCH: amd64
         run: |
-          make install
+          make build
+          make terraformrc
+          export TF_CLI_CONFIG_FILE="${PWD}/.terraformrc"
           cd examples/install
           terraform init
           terraform apply -auto-approve -var "components_extra=[\"image-reflector-controller\", \"image-automation-controller\"]"

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ cover.out
 
 # ignore tf lock file
 .terraform.lock.hcl
+
+# ignore .terraformrc for dev overrides
+.terraformrc

--- a/.terraformrc.tmpl
+++ b/.terraformrc.tmpl
@@ -1,0 +1,7 @@
+provider_installation {
+  dev_overrides {
+    "registry.terraform.io/fluxcd/flux" = "${PWD}/bin/"
+  }
+
+  direct {}
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,13 +44,14 @@ meeting](https://docs.google.com/document/d/1l_M0om0qUEN_NNiGgpqJ2tvsF2iioHkaARD
 
 ## Developing
 
-Install the required tools.
+Clone the terraform-provider-flux repository.
 
-```bash
-make tools
+```sh
+git clone https://github.com/fluxcd/terraform-provider-flux.git
+cd terraform-provider-flux
 ```
 
-Run the unit tests and acceptance tests.
+Run the unit and acceptance tests.
 
 ```bash
 make testacc
@@ -61,6 +62,15 @@ Generate the docs if you have made changes to any of the schemas or guides.
 ```sh
 make docs
 ```
+
+First build the provider, then generate a Terraform CLI config file to use a local build of the provider with Terraform.
+
+```sh
+make build
+make terraformrc
+export TF_CLI_CONFIG_FILE="${PWD}/.terraformrc"
+```
+
 
 ## Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,7 @@ testacc: tidy fmt vet
 	TF_ACC=1 go test ./... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -timeout $(ACCTEST_TIMEOUT)
 
 build:
-	CGO_ENABLED=0 go build -o ./bin/flux main.go
-
-install: build
-	mkdir -p ~/.terraform.d/plugins/registry.terraform.io/fluxcd/flux/0.0.0-dev/$${GOOS}_$${GOARCH}
-	cp ./bin/flux ~/.terraform.d/plugins/registry.terraform.io/fluxcd/flux/0.0.0-dev/$${GOOS}_$${GOARCH}/terraform-provider-flux
+	CGO_ENABLED=0 go build -o ./bin/terraform-provider-flux main.go
 
 .PHONY: docs
 docs: tools
@@ -39,3 +35,6 @@ tools:
 .SILENT:
 lint:
 	tflint --recursive --disable-rule=terraform_required_providers --disable-rule terraform_required_version --disable-rule=terraform_unused_declarations
+
+terraformrc:
+	cat .terraformrc.tmpl | envsubst > .terraformrc

--- a/examples/bootstrap-resource/main.tf
+++ b/examples/bootstrap-resource/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     flux = {
       source  = "registry.terraform.io/fluxcd/flux"
-      version = "0.0.0-dev"
+      version = ">= 0.25.0"
     }
   }
 }

--- a/examples/install-resource/main.tf
+++ b/examples/install-resource/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     flux = {
       source  = "registry.terraform.io/fluxcd/flux"
-      version = "0.0.0-dev"
+      version = ">= 0.25.0"
     }
   }
 }

--- a/examples/install/main.tf
+++ b/examples/install/main.tf
@@ -12,7 +12,7 @@ terraform {
     }
     flux = {
       source  = "fluxcd/flux"
-      version = "0.0.0-dev"
+      version = ">= 0.25.0"
     }
   }
 }


### PR DESCRIPTION
The current solution to use the locally built provider is to install the binary in the local search path. This has issues as it needs to be removed when one wants to use a provider version from the registry. This change moves to using dev overrides instead, which only applies to the configured shell.