### PR TITLE
Fix sigsev in cases where no Kubernetes configuration exists but bootstrap resource is used

### DIFF
--- a/internal/provider/provider_resource_data.go
+++ b/internal/provider/provider_resource_data.go
@@ -61,6 +61,9 @@ func NewProviderResourceData(ctx context.Context, data ProviderModel) (*provider
 }
 
 func (prd *providerResourceData) GetKubernetesClient() (client.WithWatch, error) {
+	if prd.rcg == nil {
+		return nil, fmt.Errorf("Kubernetes client cannot be created without any Kubernetes provider configuration")
+	}
 	kubeClient, err := utils.KubeClient(prd.rcg, &runclient.Options{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Users have reported issues which have been related to not having any Kubernetes configuration in the provider. I missed checking if the RCG is nil which could cause a SIGSEV. This change adds a nil check and returns a descriptive error.

Fixes #447
Part of #453 