### PR TITLE
Fix update workflow for Flux v2

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -25,8 +25,8 @@ jobs:
           RELEASE_VERSION=$(flux version --client | awk '{print $2}')
           CURRENT_VERSION=$(go list -m all | grep github.com/fluxcd/flux2 | awk '{print $2}')
           if [[ "${RELEASE_VERSION}" != "${CURRENT_VERSION}" ]]; then
-            go mod edit -require github.com/fluxcd/flux2@${RELEASE_VERSION}
-            go mod tidy -compat=1.17
+            go mod edit -require github.com/fluxcd/flux2/v2@${RELEASE_VERSION}
+            go mod tidy -compat=1.20
           fi
           git diff
 


### PR DESCRIPTION
Update package name to `github.com/fluxcd/flux2/v2`