### PR TITLE
Release 1.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.0.0-rc.3
+
+**Release date:** 2023-05-12
+
+This release includes flux2 [v2.0.0-rc.3](https://github.com/fluxcd/flux2/releases/tag/v2.0.0-rc.3).
+
 ## 1.0.0-rc.2
 
 **Release date:** 2023-05-10

--- a/docs/data-sources/install.md
+++ b/docs/data-sources/install.md
@@ -42,7 +42,7 @@ data "flux_install" "main" {
 - `network_policy` (Boolean) Deny ingress access to the toolkit controllers from other namespaces using network policies. Defaults to `true`.
 - `registry` (String) Container registry where the toolkit images are published. Defaults to `ghcr.io/fluxcd`.
 - `toleration_keys` (Set of String) List of toleration keys used to schedule the components pods onto nodes with matching taints.
-- `version` (String) Flux version. Defaults to `v2.0.0-rc.2`.
+- `version` (String) Flux version. Defaults to `v2.0.0-rc.3`.
 - `watch_all_namespaces` (Boolean) If true watch for custom resources in all namespaces. Defaults to `true`.
 
 ### Read-Only

--- a/docs/resources/bootstrap_git.md
+++ b/docs/resources/bootstrap_git.md
@@ -42,7 +42,7 @@ resource "flux_bootstrap_git" "this" {
 - `secret_name` (String) Name of the secret the sync credentials can be found in or stored to. Defaults to `flux-system`.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `toleration_keys` (Set of String) List of toleration keys used to schedule the components pods onto nodes with matching taints.
-- `version` (String) Flux version. Defaults to `v2.0.0-rc.2`.
+- `version` (String) Flux version. Defaults to `v2.0.0-rc.3`.
 - `watch_all_namespaces` (Boolean) If true watch for custom resources in all namespaces. Defaults to `true`.
 
 ### Read-Only

--- a/internal/provider/resource_bootstrap_git_test.go
+++ b/internal/provider/resource_bootstrap_git_test.go
@@ -229,7 +229,7 @@ func TestAccBootstrapGit_Upgrade(t *testing.T) {
 				),
 			},
 			{
-				Config: bootstrapGitVersion(env, "v2.0.0-rc.2"),
+				Config: bootstrapGitVersion(env, "v2.0.0-rc.3"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("flux_bootstrap_git.this", "repository_files.flux-system/kustomization.yaml"),
 					resource.TestCheckResourceAttrSet("flux_bootstrap_git.this", "repository_files.flux-system/gotk-components.yaml"),

--- a/internal/utils/flux.go
+++ b/internal/utils/flux.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package utils
 
-const DefaultFluxVersion string = "v2.0.0-rc.2"
+const DefaultFluxVersion string = "v2.0.0-rc.3"


### PR DESCRIPTION
This release includes flux2 [v2.0.0-rc.3](https://github.com/fluxcd/flux2/releases/tag/v2.0.0-rc.3).

Closes https://github.com/fluxcd/flux2/issues/3881