### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.1.1
+
+**Release date:** 2023-09-19
+
+This release includes flux2 [v2.1.1](https://github.com/fluxcd/flux2/releases/tag/v2.1.1).
+
 ## 1.1.0
 
 **Release date:** 2023-08-24

--- a/docs/resources/bootstrap_git.md
+++ b/docs/resources/bootstrap_git.md
@@ -42,7 +42,7 @@ resource "flux_bootstrap_git" "this" {
 - `secret_name` (String) Name of the secret the sync credentials can be found in or stored to. Defaults to `flux-system`.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `toleration_keys` (Set of String) List of toleration keys used to schedule the components pods onto nodes with matching taints.
-- `version` (String) Flux version. Defaults to `v2.1.0`.
+- `version` (String) Flux version. Defaults to `v2.1.1`.
 - `watch_all_namespaces` (Boolean) If true watch for custom resources in all namespaces. Defaults to `true`.
 
 ### Read-Only

--- a/internal/utils/flux.go
+++ b/internal/utils/flux.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package utils
 
-const DefaultFluxVersion string = "v2.1.0"
+const DefaultFluxVersion string = "v2.1.1"


### PR DESCRIPTION
This release includes Flux [v2.1.1](https://github.com/fluxcd/flux2/releases/tag/v2.1.1).