### PR TITLE
docs: Fix namespace typo in install-helm-release.md

### DIFF
--- a/docs/guides/install-helm-release.md
+++ b/docs/guides/install-helm-release.md
@@ -50,4 +50,4 @@ resource "helm_release" "this" {
 }
 ```
 
-After applying the example Terraform configuration, a Kind cluster should exist with Flux installed in the `flux_system` namespace.
+After applying the example Terraform configuration, a Kind cluster should exist with Flux installed in the `flux-system` namespace.

--- a/templates/guides/install-helm-release.md.tmpl
+++ b/templates/guides/install-helm-release.md.tmpl
@@ -14,4 +14,4 @@ Define a Kind cluster and pass the cluster configuration to the Helm provider al
 
 {{ tffile "examples/install-helm-release/main.tf" }}
 
-After applying the example Terraform configuration, a Kind cluster should exist with Flux installed in the `flux_system` namespace.
+After applying the example Terraform configuration, a Kind cluster should exist with Flux installed in the `flux-system` namespace.


### PR DESCRIPTION
A trival fix to misspelled namespace.