### PR TITLE
docs: Provider can deploy to pre-existing namespace

### DIFF
--- a/docs/resources/bootstrap_git.md
+++ b/docs/resources/bootstrap_git.md
@@ -35,7 +35,7 @@ resource "flux_bootstrap_git" "this" {
 - `kustomization_override` (String) Kustomization to override configuration set by default.
 - `log_level` (String) Log level for toolkit components. Defaults to `info`.
 - `manifests_path` (String) The install manifests are built from a GitHub release or kustomize overlay if using a local path. Defaults to `https://github.com/fluxcd/flux2/releases`.
-- `namespace` (String) The namespace scope for install manifests. Defaults to `flux-system`.
+- `namespace` (String) The namespace scope for install manifests. Defaults to `flux-system`. It will be created if it does not exist.
 - `network_policy` (Boolean) Deny ingress access to the toolkit controllers from other namespaces using network policies. Defaults to `true`.
 - `path` (String) Path relative to the repository root, when specified the cluster sync will be scoped to this path.
 - `recurse_submodules` (Boolean) Configures the GitRepository source to initialize and include Git submodules in the artifact it produces.

--- a/internal/provider/data_install.go
+++ b/internal/provider/data_install.go
@@ -84,7 +84,7 @@ func (s *installDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				},
 			},
 			"namespace": schema.StringAttribute{
-				Description: fmt.Sprintf("The namespace scope for install manifests. Defaults to `%s`.", opts.Namespace),
+				Description: fmt.Sprintf("The namespace scope for install manifests. Defaults to `%s`. It will be created if it does not exist.", opts.Namespace),
 				Optional:    true,
 			},
 			"cluster_domain": schema.StringAttribute{

--- a/internal/provider/resource_bootstrap_git.go
+++ b/internal/provider/resource_bootstrap_git.go
@@ -212,7 +212,7 @@ func (r *bootstrapGitResource) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 			"namespace": schema.StringAttribute{
-				Description: fmt.Sprintf("The namespace scope for install manifests. Defaults to `%s`.", defaultOpts.Namespace),
+				Description: fmt.Sprintf("The namespace scope for install manifests. Defaults to `%s`. It will be created if it does not exist.", defaultOpts.Namespace),
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString(defaultOpts.Namespace),


### PR DESCRIPTION
If `flux-system` already exists, then the provider will
use it as scope for installation of Flux manifests.

It seems important to document this behaviour to
indicate there is no need for to add a boolean
e.g. `create_namespace=true|false`.

------

I have just tested this behaviour myself using `flux_bootstrap_git` against pre-existing `flux-system` namespace with pre-existing `Secret` with Git SSH credentials:

```hcl
resource "flux_bootstrap_git" "gitops" {
  path      = "clusters/test"
  namespace = "flux-system"

  disable_secret_creation = true
  secret_name             = local.flux_github_secret
}
```