### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.2.1
+
+**Release date:** 2023-12-15
+
+This release includes flux2 [v2.2.1](https://github.com/fluxcd/flux2/releases/tag/v2.2.1).
+
 ## 1.2.0
 
 **Release date:** 2023-12-12

--- a/docs/resources/bootstrap_git.md
+++ b/docs/resources/bootstrap_git.md
@@ -43,7 +43,7 @@ resource "flux_bootstrap_git" "this" {
 - `secret_name` (String) Name of the secret the sync credentials can be found in or stored to. Defaults to `flux-system`.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `toleration_keys` (Set of String) List of toleration keys used to schedule the components pods onto nodes with matching taints.
-- `version` (String) Flux version. Defaults to `v2.2.0`.
+- `version` (String) Flux version. Defaults to `v2.2.1`.
 - `watch_all_namespaces` (Boolean) If true watch for custom resources in all namespaces. Defaults to `true`.
 
 ### Read-Only

--- a/internal/utils/flux.go
+++ b/internal/utils/flux.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package utils
 
-const DefaultFluxVersion string = "v2.2.0"
+const DefaultFluxVersion string = "v2.2.1"


### PR DESCRIPTION
Includes: https://github.com/fluxcd/flux2/releases/tag/v2.2.1

Part of: https://github.com/fluxcd/flux2/issues/4473