### PR TITLE
Update migrating-to-resource.md

### DIFF
--- a/docs/guides/migrating-to-resource.md
+++ b/docs/guides/migrating-to-resource.md
@@ -54,8 +54,8 @@ terraform {
       version = ">= 2.16.0"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14.0"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.4"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
https://registry.terraform.io/providers/gavinbunney/kubectl/latest is unmaintained. https://registry.terraform.io/providers/alekc/kubectl/latest is continuation of the effort.