### PR TITLE
Install terraform 1.7.5 during e2e tests 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -133,6 +133,11 @@ jobs:
             -d '{"name":"${{ steps.vars.outputs.test_repo_name }}", "auto_init": true}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+        with:
+          terraform_version: '1.7.5'
+          terraform_wrapper: false
       - name: Apply Terraform
         run: |
           make build

--- a/examples/github-via-ssh-with-gpg/README.md
+++ b/examples/github-via-ssh-with-gpg/README.md
@@ -7,20 +7,20 @@ The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHu
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.7.0 |
-| <a name="requirement_flux"></a> [flux](#requirement\_flux) | ~> 1.2 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.1.0 |
-| <a name="requirement_kind"></a> [kind](#requirement\_kind) | 0.4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_flux"></a> [flux](#requirement\_flux) | >= 1.2 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.1 |
+| <a name="requirement_kind"></a> [kind](#requirement\_kind) | >= 0.4 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 1.2 |
-| <a name="provider_github"></a> [github](#provider\_github) | 6.1.0 |
-| <a name="provider_kind"></a> [kind](#provider\_kind) | 0.4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.5 |
+| <a name="provider_flux"></a> [flux](#provider\_flux) | >= 1.2 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 6.1 |
+| <a name="provider_kind"></a> [kind](#provider\_kind) | >= 0.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 
 ## Modules
 
@@ -31,9 +31,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
-| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/6.1.0/docs/resources/repository_deploy_key) | resource |
-| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/0.4.0/docs/resources/cluster) | resource |
-| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/4.0.5/docs/resources/private_key) | resource |
+| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
+| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
+| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 
 ## Inputs
 

--- a/examples/github-via-ssh-with-gpg/main.tf
+++ b/examples/github-via-ssh-with-gpg/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = "= 1.7.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     flux = {
       source  = "fluxcd/flux"
-      version = "~> 1.2"
+      version = ">= 1.2"
     }
     github = {
       source  = "integrations/github"
-      version = "6.1.0"
+      version = ">= 6.1"
     }
     kind = {
       source  = "tehcyx/kind"
-      version = "0.4.0"
+      version = ">= 0.4"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.5"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/github-via-ssh/README.md
+++ b/examples/github-via-ssh/README.md
@@ -7,20 +7,20 @@ The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHu
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.7.0 |
-| <a name="requirement_flux"></a> [flux](#requirement\_flux) | ~> 1.2 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.1.0 |
-| <a name="requirement_kind"></a> [kind](#requirement\_kind) | 0.4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_flux"></a> [flux](#requirement\_flux) | >= 1.2 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.1 |
+| <a name="requirement_kind"></a> [kind](#requirement\_kind) | >= 0.4 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 1.2 |
-| <a name="provider_github"></a> [github](#provider\_github) | 6.1.0 |
-| <a name="provider_kind"></a> [kind](#provider\_kind) | 0.4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.5 |
+| <a name="provider_flux"></a> [flux](#provider\_flux) | >= 1.2 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 6.1 |
+| <a name="provider_kind"></a> [kind](#provider\_kind) | >= 0.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 
 ## Modules
 
@@ -31,9 +31,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
-| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/6.1.0/docs/resources/repository_deploy_key) | resource |
-| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/0.4.0/docs/resources/cluster) | resource |
-| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/4.0.5/docs/resources/private_key) | resource |
+| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
+| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
+| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 
 ## Inputs
 

--- a/examples/github-via-ssh/main.tf
+++ b/examples/github-via-ssh/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = "= 1.7.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     flux = {
       source  = "fluxcd/flux"
-      version = "~> 1.2"
+      version = ">= 1.2"
     }
     github = {
       source  = "integrations/github"
-      version = "6.1.0"
+      version = ">= 6.1"
     }
     kind = {
       source  = "tehcyx/kind"
-      version = "0.4.0"
+      version = ">= 0.4"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.5"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/github-with-customizations/README.md
+++ b/examples/github-with-customizations/README.md
@@ -7,20 +7,20 @@ The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHu
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.7.0 |
-| <a name="requirement_flux"></a> [flux](#requirement\_flux) | ~> 1.2 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.1.0 |
-| <a name="requirement_kind"></a> [kind](#requirement\_kind) | 0.4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_flux"></a> [flux](#requirement\_flux) | >= 1.2 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.1 |
+| <a name="requirement_kind"></a> [kind](#requirement\_kind) | >= 0.4 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 1.2 |
-| <a name="provider_github"></a> [github](#provider\_github) | 6.1.0 |
-| <a name="provider_kind"></a> [kind](#provider\_kind) | 0.4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.5 |
+| <a name="provider_flux"></a> [flux](#provider\_flux) | >= 1.2 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 6.1 |
+| <a name="provider_kind"></a> [kind](#provider\_kind) | >= 0.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 
 ## Modules
 
@@ -31,9 +31,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
-| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/6.1.0/docs/resources/repository_deploy_key) | resource |
-| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/0.4.0/docs/resources/cluster) | resource |
-| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/4.0.5/docs/resources/private_key) | resource |
+| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
+| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
+| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 
 ## Inputs
 

--- a/examples/github-with-customizations/main.tf
+++ b/examples/github-with-customizations/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = "= 1.7.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     flux = {
       source  = "fluxcd/flux"
-      version = "~> 1.2"
+      version = ">= 1.2"
     }
     github = {
       source  = "integrations/github"
-      version = "6.1.0"
+      version = ">= 6.1"
     }
     kind = {
       source  = "tehcyx/kind"
-      version = "0.4.0"
+      version = ">= 0.4"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.5"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/github-with-inline-customizations/README.md
+++ b/examples/github-with-inline-customizations/README.md
@@ -7,20 +7,20 @@ The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHu
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.7.0 |
-| <a name="requirement_flux"></a> [flux](#requirement\_flux) | ~> 1.2 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.1.0 |
-| <a name="requirement_kind"></a> [kind](#requirement\_kind) | 0.4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_flux"></a> [flux](#requirement\_flux) | >= 1.2 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.1 |
+| <a name="requirement_kind"></a> [kind](#requirement\_kind) | >= 0.4 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 1.2 |
-| <a name="provider_github"></a> [github](#provider\_github) | 6.1.0 |
-| <a name="provider_kind"></a> [kind](#provider\_kind) | 0.4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.5 |
+| <a name="provider_flux"></a> [flux](#provider\_flux) | >= 1.2 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 6.1 |
+| <a name="provider_kind"></a> [kind](#provider\_kind) | >= 0.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 
 ## Modules
 
@@ -31,9 +31,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
-| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/6.1.0/docs/resources/repository_deploy_key) | resource |
-| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/0.4.0/docs/resources/cluster) | resource |
-| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/4.0.5/docs/resources/private_key) | resource |
+| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
+| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
+| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 
 ## Inputs
 

--- a/examples/github-with-inline-customizations/main.tf
+++ b/examples/github-with-inline-customizations/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = "= 1.7.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     flux = {
       source  = "fluxcd/flux"
-      version = "~> 1.2"
+      version = ">= 1.2"
     }
     github = {
       source  = "integrations/github"
-      version = "6.1.0"
+      version = ">= 6.1"
     }
     kind = {
       source  = "tehcyx/kind"
-      version = "0.4.0"
+      version = ">= 0.4"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.5"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/gitlab-via-ssh-with-gpg/README.md
+++ b/examples/gitlab-via-ssh-with-gpg/README.md
@@ -7,20 +7,20 @@ The example demonstrates how to bootstrap a KinD cluster with Flux using a Gitla
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.7.0 |
-| <a name="requirement_flux"></a> [flux](#requirement\_flux) | ~> 1.2 |
-| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >=16.10.0 |
-| <a name="requirement_kind"></a> [kind](#requirement\_kind) | 0.4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_flux"></a> [flux](#requirement\_flux) | >= 1.2 |
+| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 16.10 |
+| <a name="requirement_kind"></a> [kind](#requirement\_kind) | >= 0.4 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 1.2 |
-| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | >=16.10.0 |
-| <a name="provider_kind"></a> [kind](#provider\_kind) | 0.4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.5 |
+| <a name="provider_flux"></a> [flux](#provider\_flux) | >= 1.2 |
+| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | >= 16.10 |
+| <a name="provider_kind"></a> [kind](#provider\_kind) | >= 0.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 
 ## Modules
 
@@ -32,8 +32,8 @@ No modules.
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
 | [gitlab_deploy_key.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/deploy_key) | resource |
-| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/0.4.0/docs/resources/cluster) | resource |
-| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/4.0.5/docs/resources/private_key) | resource |
+| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
+| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [gitlab_project.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/data-sources/project) | data source |
 
 ## Inputs

--- a/examples/gitlab-via-ssh-with-gpg/main.tf
+++ b/examples/gitlab-via-ssh-with-gpg/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = "= 1.7.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     flux = {
       source  = "fluxcd/flux"
-      version = "~> 1.2"
+      version = ">= 1.2"
     }
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = ">=16.10.0"
+      version = ">= 16.10"
     }
     kind = {
       source  = "tehcyx/kind"
-      version = "0.4.0"
+      version = ">= 0.4"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.5"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/gitlab-via-ssh/README.md
+++ b/examples/gitlab-via-ssh/README.md
@@ -7,20 +7,20 @@ The example demonstrates how to bootstrap a KinD cluster with Flux using a Gitla
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.7.0 |
-| <a name="requirement_flux"></a> [flux](#requirement\_flux) | ~> 1.2 |
-| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >=16.10.0 |
-| <a name="requirement_kind"></a> [kind](#requirement\_kind) | 0.4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_flux"></a> [flux](#requirement\_flux) | >= 1.2 |
+| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 16.10 |
+| <a name="requirement_kind"></a> [kind](#requirement\_kind) | >= 0.4 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 1.2 |
-| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | >=16.10.0 |
-| <a name="provider_kind"></a> [kind](#provider\_kind) | 0.4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.5 |
+| <a name="provider_flux"></a> [flux](#provider\_flux) | >= 1.2 |
+| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | >= 16.10 |
+| <a name="provider_kind"></a> [kind](#provider\_kind) | >= 0.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 
 ## Modules
 
@@ -32,8 +32,8 @@ No modules.
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
 | [gitlab_deploy_key.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/deploy_key) | resource |
-| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/0.4.0/docs/resources/cluster) | resource |
-| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/4.0.5/docs/resources/private_key) | resource |
+| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
+| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [gitlab_project.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/data-sources/project) | data source |
 
 ## Inputs

--- a/examples/gitlab-via-ssh/main.tf
+++ b/examples/gitlab-via-ssh/main.tf
@@ -1,22 +1,22 @@
 terraform {
-  required_version = "= 1.7.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     flux = {
       source  = "fluxcd/flux"
-      version = "~> 1.2"
+      version = ">= 1.2"
     }
     gitlab = {
       source  = "gitlabhq/gitlab"
-      version = ">=16.10.0"
+      version = ">= 16.10"
     }
     kind = {
       source  = "tehcyx/kind"
-      version = "0.4.0"
+      version = ">= 0.4"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.5"
+      version = ">= 4.0"
     }
   }
 }

--- a/examples/helm-install/README.md
+++ b/examples/helm-install/README.md
@@ -11,21 +11,21 @@ However, using the Flux Helm chart is a better option when Flux needs to be inst
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.7.0 |
-| <a name="requirement_flux"></a> [flux](#requirement\_flux) | ~> 1.2 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.12.1 |
-| <a name="requirement_kind"></a> [kind](#requirement\_kind) | 0.4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_flux"></a> [flux](#requirement\_flux) | >= 1.2 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.12 |
+| <a name="requirement_kind"></a> [kind](#requirement\_kind) | >= 0.4 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.1.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.12.1 |
-| <a name="provider_kind"></a> [kind](#provider\_kind) | 0.4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.5 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 6.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.12 |
+| <a name="provider_kind"></a> [kind](#provider\_kind) | >= 0.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 
 ## Modules
 
@@ -35,10 +35,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/6.1.0/docs/resources/repository_deploy_key) | resource |
-| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/2.12.1/docs/resources/release) | resource |
-| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/0.4.0/docs/resources/cluster) | resource |
-| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/4.0.5/docs/resources/private_key) | resource |
+| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
+| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 
 ## Inputs
 

--- a/examples/helm-install/main.tf
+++ b/examples/helm-install/main.tf
@@ -1,26 +1,26 @@
 terraform {
-  required_version = "= 1.7.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     flux = {
       source  = "fluxcd/flux"
-      version = "~> 1.2"
+      version = ">= 1.2"
     }
     github = {
       source  = "integrations/github"
-      version = "6.1.0"
+      version = ">= 6.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.12.1"
+      version = ">= 2.12"
     }
     kind = {
       source  = "tehcyx/kind"
-      version = "0.4.0"
+      version = ">= 0.4"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.5"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
Also relax provider version constraints in examples.