### PR TITLE
Updating examples to include repository creation

### DIFF
--- a/examples/github-via-ssh-with-gpg/README.md
+++ b/examples/github-via-ssh-with-gpg/README.md
@@ -2,6 +2,8 @@
 
 The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHub repository via SSH with GPG provided.
 
+Note: The GitHub repository is created and auto initialised ready for Flux to use.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -31,6 +33,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
+| [github_repository.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
 | [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
 | [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |

--- a/examples/github-via-ssh-with-gpg/main.tf
+++ b/examples/github-via-ssh-with-gpg/main.tf
@@ -30,6 +30,17 @@ resource "kind_cluster" "this" {
 }
 
 # ==========================================
+# Initialise a Github project
+# ==========================================
+
+resource "github_repository" "this" {
+  name        = var.github_repository
+  description = var.github_repository
+  visibility  = "public"
+  auto_init   = true # This is extremely important as flux_bootstrap_git will not work without a repository that has been initialised
+}
+
+# ==========================================
 # Add deploy key to GitHub repository
 # ==========================================
 
@@ -40,7 +51,7 @@ resource "tls_private_key" "flux" {
 
 resource "github_repository_deploy_key" "this" {
   title      = "Flux"
-  repository = var.github_repository
+  repository = github_repository.this.name
   key        = tls_private_key.flux.public_key_openssh
   read_only  = "false"
 }

--- a/examples/github-via-ssh/README.md
+++ b/examples/github-via-ssh/README.md
@@ -2,6 +2,8 @@
 
 The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHub repository via SSH.
 
+Note: The GitHub repository is created and auto initialised ready for Flux to use.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -31,6 +33,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
+| [github_repository.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
 | [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
 | [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |

--- a/examples/github-via-ssh/main.tf
+++ b/examples/github-via-ssh/main.tf
@@ -30,6 +30,17 @@ resource "kind_cluster" "this" {
 }
 
 # ==========================================
+# Initialise a Github project
+# ==========================================
+
+resource "github_repository" "this" {
+  name        = var.github_repository
+  description = var.github_repository
+  visibility  = "public"
+  auto_init   = true # This is extremely important as flux_bootstrap_git will not work without a repository that has been initialised
+}
+
+# ==========================================
 # Add deploy key to GitHub repository
 # ==========================================
 
@@ -40,7 +51,7 @@ resource "tls_private_key" "flux" {
 
 resource "github_repository_deploy_key" "this" {
   title      = "Flux"
-  repository = var.github_repository
+  repository = github_repository.this.name
   key        = tls_private_key.flux.public_key_openssh
   read_only  = "false"
 }

--- a/examples/github-with-customizations/README.md
+++ b/examples/github-with-customizations/README.md
@@ -2,6 +2,8 @@
 
 The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHub repository via SSH with customizations provided.
 
+Note: The GitHub repository is created and auto initialised ready for Flux to use.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -31,6 +33,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
+| [github_repository.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
 | [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
 | [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |

--- a/examples/github-with-customizations/main.tf
+++ b/examples/github-with-customizations/main.tf
@@ -30,6 +30,17 @@ resource "kind_cluster" "this" {
 }
 
 # ==========================================
+# Initialise a Github project
+# ==========================================
+
+resource "github_repository" "this" {
+  name        = var.github_repository
+  description = var.github_repository
+  visibility  = "public"
+  auto_init   = true # This is extremely important as flux_bootstrap_git will not work without a repository that has been initialised
+}
+
+# ==========================================
 # Add deploy key to GitHub repository
 # ==========================================
 
@@ -40,7 +51,7 @@ resource "tls_private_key" "flux" {
 
 resource "github_repository_deploy_key" "this" {
   title      = "Flux"
-  repository = var.github_repository
+  repository = github_repository.this.name
   key        = tls_private_key.flux.public_key_openssh
   read_only  = "false"
 }

--- a/examples/github-with-inline-customizations/README.md
+++ b/examples/github-with-inline-customizations/README.md
@@ -2,6 +2,8 @@
 
 The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHub repository via SSH with customizations provided.
 
+Note: The GitHub repository is created and auto initialised ready for Flux to use.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -31,6 +33,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
+| [github_repository.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
 | [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
 | [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |

--- a/examples/github-with-inline-customizations/main.tf
+++ b/examples/github-with-inline-customizations/main.tf
@@ -30,6 +30,17 @@ resource "kind_cluster" "this" {
 }
 
 # ==========================================
+# Initialise a Github project
+# ==========================================
+
+resource "github_repository" "this" {
+  name        = var.github_repository
+  description = var.github_repository
+  visibility  = "public"
+  auto_init   = true # This is extremely important as flux_bootstrap_git will not work without a repository that has been initialised
+}
+
+# ==========================================
 # Add deploy key to GitHub repository
 # ==========================================
 
@@ -40,7 +51,7 @@ resource "tls_private_key" "flux" {
 
 resource "github_repository_deploy_key" "this" {
   title      = "Flux"
-  repository = var.github_repository
+  repository = github_repository.this.name
   key        = tls_private_key.flux.public_key_openssh
   read_only  = "false"
 }

--- a/examples/gitlab-via-ssh-with-gpg/README.md
+++ b/examples/gitlab-via-ssh-with-gpg/README.md
@@ -1,6 +1,8 @@
 # Gitlab via SSH (with GPG)
 
-The example demonstrates how to bootstrap a KinD cluster with Flux using a Gitlab repository via SSH with GPG provided.
+The example demonstrates how to bootstrap a KinD cluster with Flux using a Gitlab project via SSH with GPG provided.
+
+Note: The Gitlab project is created and initialised with a README.md file ready for Flux to use.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -32,15 +34,14 @@ No modules.
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
 | [gitlab_deploy_key.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/deploy_key) | resource |
+| [gitlab_project.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project) | resource |
 | [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
 | [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [gitlab_project.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_gitlab_group"></a> [gitlab\_group](#input\_gitlab\_group) | The GitLab group to use for creating the GitLab project. | `string` | `""` | no |
 | <a name="input_gitlab_project"></a> [gitlab\_project](#input\_gitlab\_project) | The GitLab project to use for creating the GitLab project. | `string` | `""` | no |
 | <a name="input_gitlab_token"></a> [gitlab\_token](#input\_gitlab\_token) | The GitLab token to use for authenticating against the GitLab API. | `string` | `""` | no |
 | <a name="input_gpg_key_id"></a> [gpg\_key\_id](#input\_gpg\_key\_id) | The ID of the GPG key to use for signing commits when bootstraping FluxCD. | `string` | `""` | no |

--- a/examples/gitlab-via-ssh-with-gpg/main.tf
+++ b/examples/gitlab-via-ssh-with-gpg/main.tf
@@ -30,6 +30,17 @@ resource "kind_cluster" "this" {
 }
 
 # ==========================================
+# Initialise a Gitlab project
+# ==========================================
+
+resource "gitlab_project" "this" {
+  name                   = var.gitlab_project
+  description            = "flux-bootstrap"
+  visibility_level       = "public"
+  initialize_with_readme = true # This is extremely important as Flux expects an initialised repository
+}
+
+# ==========================================
 # Add deploy key to Gitlab repository
 # ==========================================
 
@@ -38,12 +49,8 @@ resource "tls_private_key" "flux" {
   ecdsa_curve = "P256"
 }
 
-data "gitlab_project" "this" {
-  path_with_namespace = "${var.gitlab_group}/${var.gitlab_project}"
-}
-
 resource "gitlab_deploy_key" "this" {
-  project  = data.gitlab_project.this.id
+  project  = gitlab_project.this.path_with_namespace
   title    = "Flux"
   key      = tls_private_key.flux.public_key_openssh
   can_push = true

--- a/examples/gitlab-via-ssh-with-gpg/providers.tf
+++ b/examples/gitlab-via-ssh-with-gpg/providers.tf
@@ -6,7 +6,7 @@ provider "flux" {
     cluster_ca_certificate = kind_cluster.this.cluster_ca_certificate
   }
   git = {
-    url = "ssh://git@gitlab.com/${data.gitlab_project.this.path_with_namespace}.git"
+    url = "ssh://git@gitlab.com/${gitlab_project.this.path_with_namespace}.git"
     ssh = {
       username    = "git"
       private_key = tls_private_key.flux.private_key_pem

--- a/examples/gitlab-via-ssh-with-gpg/variables.tf
+++ b/examples/gitlab-via-ssh-with-gpg/variables.tf
@@ -24,12 +24,6 @@ variable "gitlab_token" {
   default     = ""
 }
 
-variable "gitlab_group" {
-  description = "The GitLab group to use for creating the GitLab project."
-  type        = string
-  default     = ""
-}
-
 variable "gitlab_project" {
   description = "The GitLab project to use for creating the GitLab project."
   type        = string

--- a/examples/gitlab-via-ssh/README.md
+++ b/examples/gitlab-via-ssh/README.md
@@ -1,6 +1,8 @@
 # Gitlab via SSH
 
-The example demonstrates how to bootstrap a KinD cluster with Flux using a Gitlab repository via SSH.
+The example demonstrates how to bootstrap a KinD cluster with Flux using a Gitlab project via SSH.
+
+Note: The Gitlab project is created and initialised with a README.md file ready for Flux to use.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -32,15 +34,14 @@ No modules.
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
 | [gitlab_deploy_key.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/deploy_key) | resource |
+| [gitlab_project.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project) | resource |
 | [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
 | [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [gitlab_project.this](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_gitlab_group"></a> [gitlab\_group](#input\_gitlab\_group) | The GitLab group to use for creating the GitLab project. | `string` | `""` | no |
 | <a name="input_gitlab_project"></a> [gitlab\_project](#input\_gitlab\_project) | The GitLab project to use for creating the GitLab project. | `string` | `""` | no |
 | <a name="input_gitlab_token"></a> [gitlab\_token](#input\_gitlab\_token) | The GitLab token to use for authenticating against the GitLab API. | `string` | `""` | no |
 

--- a/examples/gitlab-via-ssh/main.tf
+++ b/examples/gitlab-via-ssh/main.tf
@@ -30,7 +30,18 @@ resource "kind_cluster" "this" {
 }
 
 # ==========================================
-# Add deploy key to Gitlab repository
+# Initialise a Gitlab project
+# ==========================================
+
+resource "gitlab_project" "this" {
+  name                   = var.gitlab_project
+  description            = "flux-bootstrap"
+  visibility_level       = "public"
+  initialize_with_readme = true # This is extremely important as Flux expects an initialised repository
+}
+
+# ==========================================
+# Add deploy token to Gitlab repository
 # ==========================================
 
 resource "tls_private_key" "flux" {
@@ -38,12 +49,8 @@ resource "tls_private_key" "flux" {
   ecdsa_curve = "P256"
 }
 
-data "gitlab_project" "this" {
-  path_with_namespace = "${var.gitlab_group}/${var.gitlab_project}"
-}
-
 resource "gitlab_deploy_key" "this" {
-  project  = data.gitlab_project.this.id
+  project  = gitlab_project.this.path_with_namespace
   title    = "Flux"
   key      = tls_private_key.flux.public_key_openssh
   can_push = true

--- a/examples/gitlab-via-ssh/providers.tf
+++ b/examples/gitlab-via-ssh/providers.tf
@@ -1,3 +1,5 @@
+
+
 provider "flux" {
   kubernetes = {
     host                   = kind_cluster.this.endpoint
@@ -6,7 +8,7 @@ provider "flux" {
     cluster_ca_certificate = kind_cluster.this.cluster_ca_certificate
   }
   git = {
-    url = "ssh://git@gitlab.com/${data.gitlab_project.this.path_with_namespace}.git"
+    url = "ssh://git@gitlab.com/${gitlab_project.this.path_with_namespace}.git"
     ssh = {
       username    = "git"
       private_key = tls_private_key.flux.private_key_pem

--- a/examples/gitlab-via-ssh/variables.tf
+++ b/examples/gitlab-via-ssh/variables.tf
@@ -5,12 +5,6 @@ variable "gitlab_token" {
   default     = ""
 }
 
-variable "gitlab_group" {
-  description = "The GitLab group to use for creating the GitLab project."
-  type        = string
-  default     = ""
-}
-
 variable "gitlab_project" {
   description = "The GitLab project to use for creating the GitLab project."
   type        = string


### PR DESCRIPTION
This is useful as a lot of people forget to initialise the repositories before executing `flux_bootstrap_git`