### PR TITLE
Adding hashicorp/copywrite-headers.

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,15 @@
+schema_version = 1
+
+project {
+  license           = "Apache-2.0"
+  copyright_holder  = "The Flux authors"
+  copyright_year    = 2024
+
+  # (OPTIONAL) A list of globs that should not have copyright/license headers.
+  # Supports doublestar glob patterns for more flexibility in defining which
+  # files or folders should be ignored
+  header_ignore = [
+    ".github/**",
+    ".goreleaser.yml",
+  ]
+}

--- a/.github/workflows/copywrite.yaml
+++ b/.github/workflows/copywrite.yaml
@@ -1,0 +1,28 @@
+name: Copyright Checks
+
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+  pull_request:
+    paths-ignore:
+      - .github/**
+      - .goreleaser.yml
+
+jobs:
+  go_generate:
+    name: add headers check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go install github.com/hashicorp/copywrite@latest
+      - run: copywrite headers
+      - name: Check for Git Differences
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo; echo "Unexpected difference in directories after adding copyright headers. Run 'copywrite headers' command and commit."; exit 1)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
+# Copyright (c) Flux
+# SPDX-License-Identifier: Apache-2.0
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: check-byte-order-marker
       - id: check-case-conflict
@@ -13,7 +16,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/dnephin/pre-commit-golang.git
-    rev: v0.5.0
+    rev: v0.5.1
     files: internal
     hooks:
       - id: go-fmt
@@ -23,7 +26,7 @@ repos:
       - id: go-unit-tests
       - id: golangci-lint
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.4
     files: examples
     hooks:
       - id: terraform_fmt

--- a/examples/github-via-ssh-with-gpg/main.tf
+++ b/examples/github-via-ssh-with-gpg/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 terraform {
   required_version = ">= 1.7.0"
 

--- a/examples/github-via-ssh-with-gpg/outputs.tf
+++ b/examples/github-via-ssh-with-gpg/outputs.tf
@@ -1,0 +1,2 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/github-via-ssh-with-gpg/providers.tf
+++ b/examples/github-via-ssh-with-gpg/providers.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 provider "flux" {
   kubernetes = {
     host                   = kind_cluster.this.endpoint

--- a/examples/github-via-ssh-with-gpg/variables.tf
+++ b/examples/github-via-ssh-with-gpg/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 variable "gpg_key_id" {
   description = "The ID of the GPG key to use for signing commits when bootstraping FluxCD."
   type        = string

--- a/examples/github-via-ssh/main.tf
+++ b/examples/github-via-ssh/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 terraform {
   required_version = ">= 1.7.0"
 

--- a/examples/github-via-ssh/outputs.tf
+++ b/examples/github-via-ssh/outputs.tf
@@ -1,0 +1,2 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/github-via-ssh/providers.tf
+++ b/examples/github-via-ssh/providers.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 provider "flux" {
   kubernetes = {
     host                   = kind_cluster.this.endpoint

--- a/examples/github-via-ssh/variables.tf
+++ b/examples/github-via-ssh/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 variable "github_token" {
   description = "GitHub token"
   sensitive   = true

--- a/examples/github-with-customizations/main.tf
+++ b/examples/github-with-customizations/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 terraform {
   required_version = ">= 1.7.0"
 

--- a/examples/github-with-customizations/outputs.tf
+++ b/examples/github-with-customizations/outputs.tf
@@ -1,0 +1,2 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/github-with-customizations/providers.tf
+++ b/examples/github-with-customizations/providers.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 provider "flux" {
   kubernetes = {
     host                   = kind_cluster.this.endpoint

--- a/examples/github-with-customizations/resources/flux-kustomization-patch.yaml
+++ b/examples/github-with-customizations/resources/flux-kustomization-patch.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Ref: https://fluxcd.io/flux/installation/configuration/vertical-scaling/#increase-the-number-of-workers-and-limits
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/examples/github-with-customizations/variables.tf
+++ b/examples/github-with-customizations/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 variable "github_token" {
   description = "GitHub token"
   sensitive   = true

--- a/examples/github-with-inline-customizations/main.tf
+++ b/examples/github-with-inline-customizations/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 terraform {
   required_version = ">= 1.7.0"
 

--- a/examples/github-with-inline-customizations/outputs.tf
+++ b/examples/github-with-inline-customizations/outputs.tf
@@ -1,0 +1,2 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/github-with-inline-customizations/providers.tf
+++ b/examples/github-with-inline-customizations/providers.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 provider "flux" {
   kubernetes = {
     host                   = kind_cluster.this.endpoint

--- a/examples/github-with-inline-customizations/variables.tf
+++ b/examples/github-with-inline-customizations/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 variable "github_token" {
   description = "GitHub token"
   sensitive   = true

--- a/examples/gitlab-via-ssh-with-gpg/main.tf
+++ b/examples/gitlab-via-ssh-with-gpg/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 terraform {
   required_version = ">= 1.7.0"
 

--- a/examples/gitlab-via-ssh-with-gpg/outputs.tf
+++ b/examples/gitlab-via-ssh-with-gpg/outputs.tf
@@ -1,0 +1,2 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/gitlab-via-ssh-with-gpg/providers.tf
+++ b/examples/gitlab-via-ssh-with-gpg/providers.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 provider "flux" {
   kubernetes = {
     host                   = kind_cluster.this.endpoint

--- a/examples/gitlab-via-ssh-with-gpg/variables.tf
+++ b/examples/gitlab-via-ssh-with-gpg/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 variable "gpg_key_id" {
   description = "The ID of the GPG key to use for signing commits when bootstraping FluxCD."
   type        = string

--- a/examples/gitlab-via-ssh/main.tf
+++ b/examples/gitlab-via-ssh/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 terraform {
   required_version = ">= 1.7.0"
 

--- a/examples/gitlab-via-ssh/outputs.tf
+++ b/examples/gitlab-via-ssh/outputs.tf
@@ -1,0 +1,2 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/gitlab-via-ssh/providers.tf
+++ b/examples/gitlab-via-ssh/providers.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 provider "flux" {
   kubernetes = {
     host                   = kind_cluster.this.endpoint

--- a/examples/gitlab-via-ssh/variables.tf
+++ b/examples/gitlab-via-ssh/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 variable "gitlab_token" {
   description = "The GitLab token to use for authenticating against the GitLab API."
   sensitive   = true

--- a/examples/helm-install/main.tf
+++ b/examples/helm-install/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 terraform {
   required_version = ">= 1.7.0"
 

--- a/examples/helm-install/outputs.tf
+++ b/examples/helm-install/outputs.tf
@@ -1,0 +1,2 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/helm-install/providers.tf
+++ b/examples/helm-install/providers.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 provider "github" {
   owner = var.github_org
   token = var.github_token

--- a/examples/helm-install/variables.tf
+++ b/examples/helm-install/variables.tf
@@ -1,3 +1,6 @@
+# Copyright (c) The Flux authors
+# SPDX-License-Identifier: Apache-2.0
+
 variable "github_token" {
   description = "GitHub token"
   sensitive   = true

--- a/internal/framework/types/duration.go
+++ b/internal/framework/types/duration.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package types
 

--- a/internal/framework/types/url.go
+++ b/internal/framework/types/url.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package types
 

--- a/internal/framework/validators/kustomization.go
+++ b/internal/framework/validators/kustomization.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package validators
 

--- a/internal/framework/validators/validators.go
+++ b/internal/framework/validators/validators.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package validators
 

--- a/internal/provider/data_install.go
+++ b/internal/provider/data_install.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2020 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/provider/data_install_test.go
+++ b/internal/provider/data_install_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2020 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/provider/data_sync.go
+++ b/internal/provider/data_sync.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2020 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/provider/data_sync_test.go
+++ b/internal/provider/data_sync_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2020 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/provider/provider_resource_data.go
+++ b/internal/provider/provider_resource_data.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/provider/resource_bootstrap_git.go
+++ b/internal/provider/resource_bootstrap_git.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/provider/resource_bootstrap_git_test.go
+++ b/internal/provider/resource_bootstrap_git_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package provider
 

--- a/internal/utils/datasource.go
+++ b/internal/utils/datasource.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2020 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package utils
 

--- a/internal/utils/datasource_test.go
+++ b/internal/utils/datasource_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2020 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package utils
 

--- a/internal/utils/flux.go
+++ b/internal/utils/flux.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package utils
 

--- a/internal/utils/kubernetes.go
+++ b/internal/utils/kubernetes.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package utils
 

--- a/internal/utils/kubernetes_test.go
+++ b/internal/utils/kubernetes_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2023 The Flux authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
 
 package utils
 

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Flux authors
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build tools
 // +build tools
 


### PR DESCRIPTION
Fixes #623

A lot of other upstream providers leverage this already, for example:

https://registry.terraform.io/providers/hashicorp/aws/latest
https://registry.terraform.io/providers/hashicorp/azurerm/latest
https://registry.terraform.io/providers/hashicorp/google/latest

Therefore, I thought it would be a good idea to align.