### PR TITLE
ci: Fix GitHub e2e test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,6 +99,7 @@ jobs:
         timeout-minutes: 10
   e2e-github:
     runs-on: ubuntu-latest
+    needs: build
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
@@ -122,17 +123,6 @@ jobs:
           PSEUDO_RAND_SUFFIX=$(echo "${BRANCH_NAME}-${COMMIT_SHA}" | shasum | awk '{print $1}')
           TEST_REPO_NAME="${REPOSITORY_NAME}-${PSEUDO_RAND_SUFFIX}"
           echo "test_repo_name=$TEST_REPO_NAME" >> $GITHUB_OUTPUT
-      - name: Create repository
-        run: |
-          curl \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            --fail --silent \
-            https://api.github.com/orgs/fluxcd-testing/repos \
-            -d '{"name":"${{ steps.vars.outputs.test_repo_name }}", "auto_init": true}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
       - name: Install Terraform
         uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
@@ -149,13 +139,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
       - name: Health check Flux
-        run: flux check
+        run: |
+          flux check
+          flux get all
       - name: Destroy Terraform
         run: |
           cd examples/github-via-ssh
           terraform destroy -auto-approve -var "github_token=${GITHUB_TOKEN}" -var "github_org=fluxcd-testing" -var "github_repository=${{ steps.vars.outputs.test_repo_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITPROVIDER_BOT_TOKEN }}
       - name: Delete repository
         if: ${{ always() }}
+        continue-on-error: true
         run: |
           curl \
             -X DELETE \


### PR DESCRIPTION
Adjust e2e test so that the repository is created by Terraform. Fix destroy by passing the GH token that has delete permissions. 