### PR TITLE
feat(docs): Adding example of managing the flux ssh keypair in terraform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following guides are available to help you use the provider:
 - [Bootstrapping a cluster using a GitHub repository using a personal access token (PAT)](examples/github-via-pat)
 - [Bootstrapping a cluster using a GitHub repository via SSH](examples/github-via-ssh)
 - [Bootstrapping a cluster using a GitHub repository via SSH and GPG](examples/github-via-ssh-with-gpg)
+- [Bootstrapping a cluster using a GitHub repository self-managing the SSH keypair secret)](examples/github-self-managed-ssh-keypair)
 - [Bootstrapping a cluster using a GitHub repository via SSH with flux customizations](examples/github-with-customizations)
 - [Bootstrapping a cluster using a GitHub repository via SSH and GPG with inline flux customizations](examples/github-with-inline-customizations)
 - [Bootstrapping a cluster using a Gitlab repository via SSH](examples/gitlab-via-ssh)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ The following examples are available to help you use the provider:
 - [Bootstrapping a cluster using a GitHub repository and a personal access token (PAT)](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-via-pat)
 - [Bootstrapping a cluster using a GitHub repository via SSH](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-via-ssh)
 - [Bootstrapping a cluster using a GitHub repository via SSH and GPG](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-via-ssh-with-gpg)
+- [Bootstrapping a cluster using a GitHub repository self-managing the SSH keypair secret)](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-self-managed-ssh-keypair)
 - [Bootstrapping a cluster using a GitHub repository via SSH with flux customizations](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-with-customizations)
 - [Bootstrapping a cluster using a GitHub repository via SSH and GPG with inline flux customizations](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-with-inline-customizations)
 - [Bootstrapping a cluster using a Gitlab repository via SSH](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/gitlab-via-ssh)

--- a/examples/github-self-managed-ssh-keypair/README.md
+++ b/examples/github-self-managed-ssh-keypair/README.md
@@ -1,0 +1,58 @@
+# GitHub via SSH
+
+The example demonstrates how to bootstrap a KinD cluster with Flux using a GitHub repository via SSH.
+
+The SSH keypair is managed by Terraform and can be rotated as needed.
+
+Note: The GitHub repository is created and auto initialised ready for Flux to use.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_flux"></a> [flux](#requirement\_flux) | >= 1.2 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.1 |
+| <a name="requirement_kind"></a> [kind](#requirement\_kind) | >= 0.4 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.27 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_flux"></a> [flux](#provider\_flux) | >= 1.2 |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 6.1 |
+| <a name="provider_kind"></a> [kind](#provider\_kind) | >= 0.4 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.27 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/resources/bootstrap_git) | resource |
+| [github_repository.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
+| [github_repository_deploy_key.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
+| [kind_cluster.this](https://registry.terraform.io/providers/tehcyx/kind/latest/docs/resources/cluster) | resource |
+| [kubernetes_namespace.flux_system](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_secret.ssh_keypair](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [tls_private_key.flux](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_github_org"></a> [github\_org](#input\_github\_org) | GitHub organization | `string` | `""` | no |
+| <a name="input_github_repository"></a> [github\_repository](#input\_github\_repository) | GitHub repository | `string` | `""` | no |
+| <a name="input_github_token"></a> [github\_token](#input\_github\_token) | GitHub token | `string` | `""` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/github-self-managed-ssh-keypair/main.tf
+++ b/examples/github-self-managed-ssh-keypair/main.tf
@@ -1,0 +1,103 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    flux = {
+      source  = "fluxcd/flux"
+      version = ">= 1.2"
+    }
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.1"
+    }
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.4"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.27"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+  }
+}
+
+# ========================================================================
+# Construct KinD cluster
+# ========================================================================
+
+resource "kind_cluster" "this" {
+  name = "flux-e2e"
+}
+
+# ========================================================================
+# Initialise a Github project
+# ========================================================================
+
+resource "github_repository" "this" {
+  name        = var.github_repository
+  description = var.github_repository
+  visibility  = "public"
+  auto_init   = true # This is extremely important as flux_bootstrap_git will not work without a repository that has been initialised
+}
+
+# ========================================================================
+# Add deploy key to GitHub repository
+# ========================================================================
+
+resource "tls_private_key" "flux" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
+}
+
+resource "github_repository_deploy_key" "this" {
+  title      = "Flux"
+  repository = github_repository.this.name
+  key        = tls_private_key.flux.public_key_openssh
+  read_only  = "false"
+}
+
+# ========================================================================
+# Manage the SSH keypair flux uses to authenticate with GitHub
+# ========================================================================
+
+resource "kubernetes_namespace" "flux_system" {
+  metadata {
+    name = "flux-system"
+  }
+
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
+resource "kubernetes_secret" "ssh_keypair" {
+  metadata {
+    name      = "flux-system"
+    namespace = "flux-system"
+  }
+
+  type = "Opaque"
+
+  data = {
+    "identity.pub" = tls_private_key.flux.public_key_openssh
+    "identity"     = tls_private_key.flux.private_key_pem
+    "known_hosts"  = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
+  }
+
+  depends_on = [kubernetes_namespace.flux_system]
+}
+
+# ========================================================================
+# Bootstrap KinD cluster
+# ========================================================================
+
+resource "flux_bootstrap_git" "this" {
+  depends_on = [github_repository_deploy_key.this, kubernetes_secret.ssh_keypair]
+
+  path                    = "clusters/my-cluster"
+  disable_secret_creation = true
+}

--- a/examples/github-self-managed-ssh-keypair/providers.tf
+++ b/examples/github-self-managed-ssh-keypair/providers.tf
@@ -1,0 +1,29 @@
+provider "flux" {
+  kubernetes = {
+    host                   = kind_cluster.this.endpoint
+    client_certificate     = kind_cluster.this.client_certificate
+    client_key             = kind_cluster.this.client_key
+    cluster_ca_certificate = kind_cluster.this.cluster_ca_certificate
+  }
+  git = {
+    url = "ssh://git@github.com/${var.github_org}/${var.github_repository}.git"
+    ssh = {
+      username    = "git"
+      private_key = tls_private_key.flux.private_key_pem
+    }
+  }
+}
+
+provider "github" {
+  owner = var.github_org
+  token = var.github_token
+}
+
+provider "kind" {}
+
+provider "kubernetes" {
+  host                   = kind_cluster.this.endpoint
+  client_certificate     = kind_cluster.this.client_certificate
+  client_key             = kind_cluster.this.client_key
+  cluster_ca_certificate = kind_cluster.this.cluster_ca_certificate
+}

--- a/examples/github-self-managed-ssh-keypair/variables.tf
+++ b/examples/github-self-managed-ssh-keypair/variables.tf
@@ -1,0 +1,18 @@
+variable "github_token" {
+  description = "GitHub token"
+  sensitive   = true
+  type        = string
+  default     = ""
+}
+
+variable "github_org" {
+  description = "GitHub organization"
+  type        = string
+  default     = ""
+}
+
+variable "github_repository" {
+  description = "GitHub repository"
+  type        = string
+  default     = ""
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -18,6 +18,7 @@ The following examples are available to help you use the provider:
 - [Bootstrapping a cluster using a GitHub repository and a personal access token (PAT)](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-via-pat)
 - [Bootstrapping a cluster using a GitHub repository via SSH](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-via-ssh)
 - [Bootstrapping a cluster using a GitHub repository via SSH and GPG](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-via-ssh-with-gpg)
+- [Bootstrapping a cluster using a GitHub repository self-managing the SSH keypair secret)](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-self-managed-ssh-keypair)
 - [Bootstrapping a cluster using a GitHub repository via SSH with flux customizations](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-with-customizations)
 - [Bootstrapping a cluster using a GitHub repository via SSH and GPG with inline flux customizations](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/github-with-inline-customizations)
 - [Bootstrapping a cluster using a Gitlab repository via SSH](https://github.com/fluxcd/terraform-provider-flux/tree/main/examples/gitlab-via-ssh)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds an example showing how to manage the SSH keypair flux uses in Terraform for easier rotation.

## Motivation and Context
Fixes #646 
Discussed in https://github.com/fluxcd/terraform-provider-flux/issues/596

## How has this been tested?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation
- [x] I have updated the documentation (if required) with `make docs`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/fluxcd/terraform-provider-flux/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

## Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritise this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
