### PR TITLE
Adding optional git manifest delete.

### DIFF
--- a/docs/resources/bootstrap_git.md
+++ b/docs/resources/bootstrap_git.md
@@ -30,6 +30,7 @@ The following examples are available to help you use the provider:
 - `cluster_domain` (String) The internal cluster domain. Defaults to `cluster.local`
 - `components` (Set of String) Toolkit components to include in the install manifests. Defaults to `[source-controller kustomize-controller helm-controller notification-controller]`
 - `components_extra` (Set of String) List of extra components to include in the install manifests.
+- `delete_git_manifests` (Boolean) Delete manifests from git repository. Defaults to `true`.
 - `disable_secret_creation` (Boolean) Use the existing secret for flux controller and don't create one from bootstrap
 - `image_pull_secret` (String) Kubernetes secret name used for pulling the toolkit images from a private registry.
 - `interval` (String) Interval at which to reconcile from bootstrap repository. Defaults to `1m0s`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows you to choose whether or not to delete the git optionally manifests when executing `terraform destroy`

## Motivation and Context
Fixes #649 

## How has this been tested?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation
- [x] I have updated the documentation (if required) with `make docs`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/fluxcd/terraform-provider-flux/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

## Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritise this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
