### PR TITLE
Add simple module that can be used to install Flux directly from manifests

### DIFF
--- a/examples/kustomize-build/main.tf
+++ b/examples/kustomize-build/main.tf
@@ -1,0 +1,12 @@
+locals {
+  flux_manifests_path = abspath(var.flux_root_dir)
+}
+
+data "kustomization_build" "flux" {
+  path = local.flux_manifests_path
+}
+
+resource "kubernetes_manifest" "flux" {
+  for_each = data.kustomization_build.flux.manifests
+  manifest = each.value
+}

--- a/examples/kustomize-build/variables.tf
+++ b/examples/kustomize-build/variables.tf
@@ -1,0 +1,3 @@
+variable "flux_root_dir" {
+  type = string
+}

--- a/examples/kustomize-build/versions.tf
+++ b/examples/kustomize-build/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.29"
+    }
+    kustomization = {
+      source  = "kbst/kustomization"
+      version = "~> 0.9"
+    }
+  }
+
+  required_version = ">= 1.6.0"
+}


### PR DESCRIPTION
This a simple example that show how to install flux into a cluster without using `flux_bootstrap_git` resource, which can be challenging if getting GitHub access token is challenging. It's also an alternative to the Helm example, in the way that it assumes Flux manifests have already been provided in the same repository.