### PR TITLE
Add `hostkey_algos` to the `git.ssh` schema

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -163,6 +163,7 @@ Optional:
 
 Optional:
 
+- `hostkey_algos` (List of String) The list of hostkey algorithms to use for ssh connections, arranged from most preferred to the least.
 - `password` (String, Sensitive) Password of the SSH private key.
 - `private_key` (String, Sensitive) Private key used for authenticating to the Git SSH server.
 - `username` (String) Username for Git SSH server.

--- a/internal/provider/resource_bootstrap_git_test.go
+++ b/internal/provider/resource_bootstrap_git_test.go
@@ -543,6 +543,7 @@ func bootstrapGitSSH(env environment) string {
         url = "%s"
         ssh = {
           username = "git"
+          hostkey_algos = ["rsa-sha2-512", "rsa-sha2-256"]
           private_key = <<EOF
 %s
 EOF


### PR DESCRIPTION
## Description

Allow configuring the list of host key algorithms to use for SSH connections  initialised by the provider during bootstrap.

## Motivation and Context

Closes: #678 

xref: https://github.com/fluxcd/flux2/pull/4754

## How has this been tested?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation
- [x] I have updated the documentation (if required) with `make docs`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/fluxcd/terraform-provider-flux/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

