### PR TITLE
Adding registry credential support to bootstrap resource.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - godot
     - gofmt
     - gosimple
+    - govet
     - makezero
     - misspell
     - nilerr
@@ -23,4 +24,3 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet

--- a/docs/resources/bootstrap_git.md
+++ b/docs/resources/bootstrap_git.md
@@ -44,6 +44,7 @@ The following examples are available to help you use the provider:
 - `path` (String) Path relative to the repository root, when specified the cluster sync will be scoped to this path (immutable).
 - `recurse_submodules` (Boolean) Configures the GitRepository source to initialize and include Git submodules in the artifact it produces.
 - `registry` (String) Container registry where the toolkit images are published. Defaults to `ghcr.io/fluxcd`.
+- `registry_credentials` (String) Container registry credentials in the format 'user:password'
 - `secret_name` (String) Name of the secret the sync credentials can be found in or stored to. Defaults to `flux-system`.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `toleration_keys` (Set of String) List of toleration keys used to schedule the components pods onto nodes with matching taints.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows the user to provide registry credentials in the form `username: password`

## Motivation and Context
Fixes https://github.com/fluxcd/terraform-provider-flux/issues/635
Leverages upstream fluxcd/flux2 PR: https://github.com/fluxcd/flux2/pull/4706/files

## How has this been tested?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc

...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation
- [x] I have updated the documentation (if required) with `make docs`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/fluxcd/terraform-provider-flux/blob/main/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`

## Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritise this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
