### PR TITLE
Stepping down as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5,10 +5,10 @@ https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages
 In alphabetical order:
 
 Stefan Prodan, ControlPlane <stefan.prodan@gmail.com> (github: @stefanprodan, slack: stefanprodan)
-Steven Wade, Independent <steven@stevenwade.co.uk> (github: @swade1987, slack: Steve Wade)
 
 Retired maintainers:
 
 - Philip Laine
+- Steven Wade
 
 Thank you for your involvement, and let us not say "farewell" ...


### PR DESCRIPTION
After much reflection, I've decided to step down from my role as a maintainer of the Flux Terraform provider. This wasn't an easy choice, but with increased client engagements and my full-time work commitments, I realised I couldn't dedicate the time and attention this responsibility truly deserves.

This role has been significant to me as it fulfilled a long-time dream of giving back to the Flux team. Their support was invaluable during my journey, from my early days using v1 through the challenges of upgrading to v2. Contributing to this community that helped me so much has been incredibly fulfilling.

While stepping back from maintainer duties, I remain committed to the community and look forward to continuing our connections, albeit in a different capacity.

Thank you to everyone who has shared this journey with me. Your support and understanding mean the world to me 💙 .