### PR TITLE
Fix helm-install example e2e test

### DIFF
--- a/examples/helm-install/main.tf
+++ b/examples/helm-install/main.tf
@@ -114,25 +114,24 @@ resource "helm_release" "flux2_sync" {
   name      = "flux-system"
   namespace = "flux-system"
 
-  set {
-    name  = "gitRepository.spec.url"
-    value = "ssh://git@github.com/${var.github_org}/${var.github_repository}.git"
-  }
-
-  set {
-    name  = "gitRepository.spec.ref.branch"
-    value = "main"
-  }
-
-  set {
-    name  = "gitRepository.spec.secretRef.name"
-    value = kubernetes_secret.ssh_keypair.metadata[0].name
-  }
-
-  set {
-    name  = "gitRepository.spec.interval"
-    value = "1m"
-  }
+  set = [
+    {
+      name  = "gitRepository.spec.url"
+      value = "ssh://git@github.com/${var.github_org}/${var.github_repository}.git"
+    },
+    {
+      name  = "gitRepository.spec.ref.branch"
+      value = "main"
+    },
+    {
+      name  = "gitRepository.spec.secretRef.name"
+      value = kubernetes_secret.ssh_keypair.metadata[0].name
+    },
+    {
+      name  = "gitRepository.spec.interval"
+      value = "1m"
+    }
+  ]
 
   depends_on = [helm_release.flux2]
 }

--- a/examples/helm-install/providers.tf
+++ b/examples/helm-install/providers.tf
@@ -4,7 +4,7 @@ provider "github" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = kind_cluster.this.endpoint
     client_certificate     = kind_cluster.this.client_certificate
     client_key             = kind_cluster.this.client_key


### PR DESCRIPTION
Fixing this error:

https://github.com/fluxcd/terraform-provider-flux/actions/runs/15969999299/job/45040563296

```
│ Error: Unsupported block type
│ 
│   on providers.tf line 7, in provider "helm":
│    7:   kubernetes {
│ 
│ Blocks of type "kubernetes" are not expected here. Did you mean to define
│ argument "kubernetes"? If so, use the equals sign to assign it a value.
```