### PR TITLE
ci: Build release with ubuntu-latest-16-cores

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,9 @@ jobs:
   goreleaser:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "Default Larger Runners"
+      labels: ubuntu-latest-16-cores
     permissions:
       contents: write # needed to write releases
       id-token: write # needed for keyless signing


### PR DESCRIPTION
Try to fix:

```
    │ compile: writing output: write $WORK/b1312/_pkg_.a: no space left on device
    target=darwin_arm64_v8.0
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.12.7/x64/goreleaser' failed with exit code 1
```