### PR TITLE
Handle legacy events address during import

### DIFF
--- a/internal/provider/resource_bootstrap_git.go
+++ b/internal/provider/resource_bootstrap_git.go
@@ -1003,11 +1003,18 @@ func (r *bootstrapGitResource) ImportState(ctx context.Context, req resource.Imp
 		resp.Diagnostics.AddError("Could not parse events address", err.Error())
 		return
 	}
-	// TODO: Probably smarter to remove what we know comes before the cluster domain and remove that.
-	host := strings.TrimSuffix(eventsUrl.Host, ".")
-	c := strings.Split(host, ".")
-	clusterDomain := strings.Join(c[len(c)-2:], ".")
+	clusterDomain, inferredClusterDomain, err := getClusterDomainFromEventsAddress(eventsUrl.String(), data.Namespace.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Could not determine cluster domain", err.Error())
+		return
+	}
 	data.ClusterDomain = types.StringValue(clusterDomain)
+	if !inferredClusterDomain {
+		resp.Diagnostics.AddWarning(
+			"Could not infer cluster domain from events address",
+			fmt.Sprintf("The controller events address %q does not include a cluster domain; using the default %q during import. If your cluster uses a custom domain, set the cluster_domain attribute after import.", value, clusterDomain),
+		)
+	}
 
 	// Get values from flux-system GitRepository.
 	gitRepository := sourcev1.GitRepository{
@@ -1122,6 +1129,37 @@ resources:
 - gotk-components.yaml
 - gotk-sync.yaml
 `
+}
+
+func getClusterDomainFromEventsAddress(eventsAddress, namespace string) (string, bool, error) {
+	eventsURL, err := url.Parse(eventsAddress)
+	if err != nil {
+		return "", false, err
+	}
+
+	host := strings.TrimSuffix(eventsURL.Hostname(), ".")
+	if host == "" {
+		return "", false, fmt.Errorf("events address does not contain a host")
+	}
+
+	defaultClusterDomain := install.MakeDefaultOptions().ClusterDomain
+	serviceHost := fmt.Sprintf("notification-controller.%s.svc", namespace)
+
+	if host == serviceHost {
+		return defaultClusterDomain, false, nil
+	}
+
+	prefix := serviceHost + "."
+	if !strings.HasPrefix(host, prefix) {
+		return defaultClusterDomain, false, nil
+	}
+
+	clusterDomain := strings.TrimPrefix(host, prefix)
+	if clusterDomain == "" {
+		return defaultClusterDomain, false, nil
+	}
+
+	return clusterDomain, true, nil
 }
 
 func getInstallOptions(data bootstrapGitResourceData) install.Options {

--- a/internal/provider/resource_bootstrap_git_import_test.go
+++ b/internal/provider/resource_bootstrap_git_import_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/fluxcd/flux2/v2/pkg/manifestgen/install"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClusterDomainFromEventsAddress(t *testing.T) {
+	defaultClusterDomain := install.MakeDefaultOptions().ClusterDomain
+
+	tests := []struct {
+		name                  string
+		eventsAddress         string
+		namespace             string
+		expectedClusterDomain string
+		expectedInferred      bool
+		expectedError         string
+	}{
+		{
+			name:                  "infers cluster domain from fully qualified service address",
+			eventsAddress:         "http://notification-controller.flux-system.svc.cluster.local./",
+			namespace:             "flux-system",
+			expectedClusterDomain: "cluster.local",
+			expectedInferred:      true,
+		},
+		{
+			name:                  "infers custom cluster domain",
+			eventsAddress:         "http://notification-controller.flux-system.svc.corp.example.internal./",
+			namespace:             "flux-system",
+			expectedClusterDomain: "corp.example.internal",
+			expectedInferred:      true,
+		},
+		{
+			name:                  "falls back to default for service host without cluster domain",
+			eventsAddress:         "http://notification-controller.flux-system.svc/",
+			namespace:             "flux-system",
+			expectedClusterDomain: defaultClusterDomain,
+			expectedInferred:      false,
+		},
+		{
+			name:                  "falls back to default for short service host",
+			eventsAddress:         "http://notification-controller/",
+			namespace:             "flux-system",
+			expectedClusterDomain: defaultClusterDomain,
+			expectedInferred:      false,
+		},
+		{
+			name:                  "falls back to default for unexpected host shape",
+			eventsAddress:         "http://other-service.flux-system.svc.cluster.local./",
+			namespace:             "flux-system",
+			expectedClusterDomain: defaultClusterDomain,
+			expectedInferred:      false,
+		},
+		{
+			name:          "fails for hostless address",
+			eventsAddress: "notification-controller",
+			namespace:     "flux-system",
+			expectedError: "events address does not contain a host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterDomain, inferred, err := getClusterDomainFromEventsAddress(tt.eventsAddress, tt.namespace)
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedClusterDomain, clusterDomain)
+			require.Equal(t, tt.expectedInferred, inferred)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Handle legacy `--events-addr` values during `flux_bootstrap_git` import without panicking.

## Motivation and Context
Older Flux installations can expose `notification-controller` as a short service host such as `http://notification-controller/`. Import currently assumes a fully qualified service DNS name and slices the last two labels, which panics on those legacy values.

Fixes #808.

## How has this been tested?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```text
$ go test ./internal/framework/... ./internal/utils ./internal/provider -run TestGetClusterDomainFromEventsAddress
?    github.com/fluxcd/terraform-provider-flux/internal/framework/types        [no test files]
?    github.com/fluxcd/terraform-provider-flux/internal/framework/validators   [no test files]
ok   github.com/fluxcd/terraform-provider-flux/internal/utils                  0.015s [no tests to run]
ok   github.com/fluxcd/terraform-provider-flux/internal/provider               0.019s

$ go test ./...
FAIL github.com/fluxcd/terraform-provider-flux/internal/provider
# Acceptance tests require Kind; in this environment Kind fails to boot with:
# could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation
- [ ] I have updated the documentation (if required) with `make docs`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/fluxcd/terraform-provider-flux/blob/main/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

## Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritise this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
