### PR TITLE
Install Terraform in update-flux workflow

### DIFF
--- a/.github/workflows/update-flux.yaml
+++ b/.github/workflows/update-flux.yaml
@@ -20,6 +20,10 @@ jobs:
         uses: fluxcd/flux2/action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
       - name: Check for new Flux version
         id: version
         run: |


### PR DESCRIPTION
The `update-flux` workflow has been failing `make docs` with:

```
error exporting provider schema from Terraform: unable to download Terraform binary:
unable to verify checksums signature: openpgp: key expired
```

`tfplugindocs` (invoked by `make docs`) uses `hc-install` to fetch the Terraform binary on-the-fly and verify HashiCorp's checksums PGP signature. The key embedded in `hc-install` has expired, so every `update-flux` run currently produces a dirty tree that the `build` CI check rejects — forcing a manual amend + force-push for every Flux patch release.

`tfplugindocs` prefers a Terraform CLI binary from `PATH` when available and skips the download entirely. Adding `hashicorp/setup-terraform` before the update step puts `terraform` on `PATH` and works around the expired key until `hc-install` / `terraform-plugin-docs` ship a refreshed one.