### PR TITLE
Reduce runner size for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,14 +8,20 @@ jobs:
   goreleaser:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
-    runs-on:
-      group: "Default Larger Runners"
-      labels: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     permissions:
       contents: write # needed to write releases
       id-token: write # needed for keyless signing
       packages: write # needed for ghcr access
     steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          df -h
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:


### PR DESCRIPTION
The `release` job currently pins to the `Default Larger Runners` group (`ubuntu-latest-16-cores`). Larger runners are not available at the moment, which left the v1.8.6 release run queued indefinitely after tag push.

Switch to standard `ubuntu-latest` and free ~12GB upfront by removing preinstalled toolchains the release doesn't use (.NET, Android SDK, GHC/Haskell), mirroring the cleanup pattern used in `controlplaneio-fluxcd/flux-operator`'s release workflow. This keeps goreleaser with plenty of disk space while removing the large-runner dependency.

Once this merges, v1.8.6 will be re-tagged to pick up the fixed workflow.